### PR TITLE
Make sequential RPC method requests when Nitro payments is configured

### DIFF
--- a/packages/core/src/Ponder.ts
+++ b/packages/core/src/Ponder.ts
@@ -398,6 +398,8 @@ export class Ponder {
           chainId,
         });
 
+        // If payment service is setup, start the realtime sync service after historical sync service.
+        // This will avoid parallel requests to RPC endpoint
         if (this.paymentService) {
           realtimeSyncService.start();
         }

--- a/packages/core/src/Ponder.ts
+++ b/packages/core/src/Ponder.ts
@@ -264,9 +264,11 @@ export class Ponder {
         async ({ historicalSyncService, realtimeSyncService }) => {
           const blockNumbers = await realtimeSyncService.setup();
           await historicalSyncService.setup(blockNumbers);
-
           historicalSyncService.start();
-          realtimeSyncService.start();
+
+          if (!this.paymentService) {
+            realtimeSyncService.start();
+          }
         }
       )
     );
@@ -301,9 +303,11 @@ export class Ponder {
         async ({ historicalSyncService, realtimeSyncService }) => {
           const blockNumbers = await realtimeSyncService.setup();
           await historicalSyncService.setup(blockNumbers);
-
           historicalSyncService.start();
-          realtimeSyncService.start();
+
+          if (!this.paymentService) {
+            realtimeSyncService.start();
+          }
         }
       )
     );
@@ -393,6 +397,10 @@ export class Ponder {
         this.eventAggregatorService.handleHistoricalSyncComplete({
           chainId,
         });
+
+        if (this.paymentService) {
+          realtimeSyncService.start();
+        }
       });
 
       realtimeSyncService.on("realtimeCheckpoint", ({ timestamp }) => {

--- a/packages/core/src/config/networks.ts
+++ b/packages/core/src/config/networks.ts
@@ -4,7 +4,11 @@ import { mainnet } from "viem/chains";
 import type { ResolvedConfig } from "@/config/config";
 import { PaymentService } from "@/payment/service";
 
-const PAID_RPC_METHODS = ["eth_getLogs"];
+const PAID_RPC_METHODS = [
+  "eth_getLogs",
+  "eth_getBlockByNumber",
+  "eth_getBlockByHash",
+];
 
 export type Network = {
   name: string;

--- a/packages/core/src/realtime-sync/service.ts
+++ b/packages/core/src/realtime-sync/service.ts
@@ -404,6 +404,7 @@ export class RealtimeSyncService extends Emittery<RealtimeSyncEvents> {
       );
 
       // Fetch all missing blocks using a request concurrency limit of 10.
+      // TODO: Make realtime block fetch concurrency configurable.
       const limit = pLimit(10);
 
       const missingBlockRequests = missingBlockNumbers.map((number) => {

--- a/packages/core/src/realtime-sync/service.ts
+++ b/packages/core/src/realtime-sync/service.ts
@@ -404,8 +404,7 @@ export class RealtimeSyncService extends Emittery<RealtimeSyncEvents> {
       );
 
       // Fetch all missing blocks using a request concurrency limit of 10.
-      // TODO: Make realtime block fetch concurrency configurable.
-      const limit = pLimit(10);
+      const limit = pLimit(this.network.maxRpcRequestConcurrency);
 
       const missingBlockRequests = missingBlockNumbers.map((number) => {
         return limit(async () => {


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/416

- Start realtime sync service after historical sync is complete when Nitro payments is configured
- Use config `maxRpcRequestConcurrency` in realtime sync service