### PR TITLE
Get nitro fund amounts and paid RPC methods from config

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,8 +33,8 @@
   },
   "dependencies": {
     "@babel/code-frame": "^7.18.6",
-    "@cerc-io/nitro-node": "^0.1.11",
-    "@cerc-io/nitro-util": "^0.1.11",
+    "@cerc-io/nitro-node": "^0.1.13",
+    "@cerc-io/nitro-util": "^0.1.13",
     "@cerc-io/peer": "^0.2.60",
     "@jridgewell/trace-mapping": "^0.3.17",
     "async-mutex": "^0.4.0",

--- a/packages/core/src/Ponder.ts
+++ b/packages/core/src/Ponder.ts
@@ -90,7 +90,7 @@ export class Ponder {
 
     if (config.nitro) {
       this.paymentService = new PaymentService({
-        config: config.nitro,
+        config,
         common,
       });
     }
@@ -230,8 +230,14 @@ export class Ponder {
       // Initialize payment service with Nitro node
       await this.paymentService.init();
 
-      // Setup payment channel nitro
-      await this.paymentService.setupPaymentChannel();
+      // Setup payment channel with Nitro nodes
+      const paymentChannelSetupPromises = this.networkSyncServices.map(
+        async ({ network }) => {
+          return this.paymentService!.setupPaymentChannel(network.name);
+        }
+      );
+
+      await Promise.all(paymentChannelSetupPromises);
     }
 
     return undefined;

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -106,7 +106,7 @@ export type ResolvedConfig = {
   nitro?: {
     privateKey: string;
     chainPrivateKey: string;
-    chainURL: string;
+    chainUrl: string;
     contractAddresses: { [key: string]: string };
     relayMultiAddr: string;
     store: string;

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -30,6 +30,22 @@ export type ResolvedConfig = {
     pollingInterval?: number;
     /** Maximum concurrency of RPC requests during the historical sync. Default: `10`. */
     maxRpcRequestConcurrency?: number;
+    /** Configuration of payments required for network requests */
+    payments?: {
+      nitro: {
+        address: string;
+        multiAddr: string;
+        /** Funding amounts for Nitro channels created with the node */
+        fundingAmounts: {
+          directFund: string;
+          virtualFund: string;
+        };
+      };
+      /** List of RPC methods which require payment */
+      paidRPCMethods: string[];
+      /** Amount to be paid for each network request */
+      amount: string;
+    };
   }[];
   /** List of contracts to fetch & handle events from. Contracts defined here will be present in `context.contracts`. */
   contracts?: {
@@ -93,12 +109,7 @@ export type ResolvedConfig = {
     chainURL: string;
     contractAddresses: { [key: string]: string };
     relayMultiAddr: string;
-    rpcNitroNode: {
-      address: string;
-      multiAddr: string;
-    };
     store: string;
-    payAmount: string;
   };
 };
 

--- a/packages/core/src/config/networks.ts
+++ b/packages/core/src/config/networks.ts
@@ -45,12 +45,12 @@ export function buildNetwork({
       // TODO: Implement a custom transport to change query params when making requests
       transport: custom({
         async request({ method, params }) {
-          let url = `${network.rpcUrl}?method=${method}`;
+          let url = network.rpcUrl;
 
           if (paymentService && PAID_RPC_METHODS.includes(method)) {
             // Make payment before RPC request
             const voucher = await paymentService.createVoucher(network.name);
-            url = `${url}&channelId=${voucher.channelId.string()}&amount=${voucher.amount?.toString()}&signature=${voucher.signature.toHexString()}`;
+            url = `${url}?channelId=${voucher.channelId.string()}&amount=${voucher.amount?.toString()}&signature=${voucher.signature.toHexString()}`;
           }
 
           const httpTransport = http(url);

--- a/packages/core/src/config/networks.ts
+++ b/packages/core/src/config/networks.ts
@@ -49,7 +49,7 @@ export function buildNetwork({
 
           if (paymentService && PAID_RPC_METHODS.includes(method)) {
             // Make payment before RPC request
-            const voucher = await paymentService.createVoucher();
+            const voucher = await paymentService.createVoucher(network.name);
             url = `${url}&channelId=${voucher.channelId.string()}&amount=${voucher.amount?.toString()}&signature=${voucher.signature.toHexString()}`;
           }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -286,11 +286,11 @@ importers:
         specifier: ^7.18.6
         version: 7.18.6
       '@cerc-io/nitro-node':
-        specifier: ^0.1.11
-        version: 0.1.11(@ethersproject/abi@5.7.0)(@ethersproject/bytes@5.7.0)(@ethersproject/providers@5.7.2)(typechain@7.0.1)(typescript@5.1.3)
+        specifier: ^0.1.13
+        version: 0.1.13(@ethersproject/abi@5.7.0)(@ethersproject/bytes@5.7.0)(@ethersproject/providers@5.7.2)(typechain@7.0.1)(typescript@5.1.3)
       '@cerc-io/nitro-util':
-        specifier: ^0.1.11
-        version: 0.1.11(@ethersproject/abi@5.7.0)(@ethersproject/bytes@5.7.0)(@ethersproject/providers@5.7.2)(typechain@7.0.1)(typescript@5.1.3)
+        specifier: ^0.1.13
+        version: 0.1.13(@ethersproject/abi@5.7.0)(@ethersproject/bytes@5.7.0)(@ethersproject/providers@5.7.2)(typechain@7.0.1)(typescript@5.1.3)
       '@cerc-io/peer':
         specifier: ^0.2.60
         version: 0.2.60
@@ -1927,18 +1927,18 @@ packages:
       - supports-color
     dev: false
 
-  /@cerc-io/nitro-node@0.1.11(@ethersproject/abi@5.7.0)(@ethersproject/bytes@5.7.0)(@ethersproject/providers@5.7.2)(typechain@7.0.1)(typescript@5.1.3):
-    resolution: {integrity: sha512-1SaieVkcSlkhSQqJqxgr1rlR9FA+FIzFOuAbr1Afx9E4N2EtUoG2XAsYxi9LIYBEwEcBUIelpvXe4TZLDhFVjg==, tarball: https://git.vdb.to/api/packages/cerc-io/npm/%40cerc-io%2Fnitro-node/-/0.1.11/nitro-node-0.1.11.tgz}
+  /@cerc-io/nitro-node@0.1.13(@ethersproject/abi@5.7.0)(@ethersproject/bytes@5.7.0)(@ethersproject/providers@5.7.2)(typechain@7.0.1)(typescript@5.1.3):
+    resolution: {integrity: sha512-U64qUUjla/sRyfnPC/12qNqDa+5R+1GlVZE1CO50vIhf2wTA2Sr7xwhqbGo277YhjD9xfalyZPZ0BiIvaAXBCQ==, tarball: https://git.vdb.to/api/packages/cerc-io/npm/%40cerc-io%2Fnitro-node/-/0.1.13/nitro-node-0.1.13.tgz}
     dependencies:
       '@cerc-io/libp2p': 0.42.2-laconic-0.1.4
-      '@cerc-io/nitro-protocol': 2.0.0-alpha.4-ts-port-0.1.3(@ethersproject/abi@5.7.0)(@ethersproject/bytes@5.7.0)(@ethersproject/providers@5.7.2)(ethers@5.7.2)(typechain@7.0.1)(typescript@5.1.3)
-      '@cerc-io/nitro-util': 0.1.11(@ethersproject/abi@5.7.0)(@ethersproject/bytes@5.7.0)(@ethersproject/providers@5.7.2)(typechain@7.0.1)(typescript@5.1.3)
+      '@cerc-io/nitro-util': 0.1.13(@ethersproject/abi@5.7.0)(@ethersproject/bytes@5.7.0)(@ethersproject/providers@5.7.2)(typechain@7.0.1)(typescript@5.1.3)
       '@cerc-io/peer': 0.2.60
       '@cerc-io/ts-channel': 1.0.3-ts-nitro-0.1.1
       '@jpwilliams/waitgroup': 2.1.0
       '@libp2p/crypto': 1.0.17
       '@libp2p/tcp': 6.2.2
       '@multiformats/multiaddr': 11.6.1
+      '@statechannels/nitro-protocol': 2.0.0-alpha.5(@ethersproject/abi@5.7.0)(@ethersproject/bytes@5.7.0)(@ethersproject/providers@5.7.2)(ethers@5.7.2)(typechain@7.0.1)(typescript@5.1.3)
       assert: 2.1.0
       async-mutex: 0.4.0
       debug: 4.3.4(supports-color@8.1.1)
@@ -1961,29 +1961,11 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@cerc-io/nitro-protocol@2.0.0-alpha.4-ts-port-0.1.3(@ethersproject/abi@5.7.0)(@ethersproject/bytes@5.7.0)(@ethersproject/providers@5.7.2)(ethers@5.7.2)(typechain@7.0.1)(typescript@5.1.3):
-    resolution: {integrity: sha512-jDZLpw2fvLGqFMNodLkykn/qTEdEyNhxRloKVgdWU973CScV85Q/j5QDsDA87aF4iDOqrgGJkgIs36+MDcXngA==, tarball: https://git.vdb.to/api/packages/cerc-io/npm/%40cerc-io%2Fnitro-protocol/-/2.0.0-alpha.4-ts-port-0.1.3/nitro-protocol-2.0.0-alpha.4-ts-port-0.1.3.tgz}
-    engines: {node: '>=18.5.0'}
+  /@cerc-io/nitro-util@0.1.13(@ethersproject/abi@5.7.0)(@ethersproject/bytes@5.7.0)(@ethersproject/providers@5.7.2)(typechain@7.0.1)(typescript@5.1.3):
+    resolution: {integrity: sha512-jlGGaGx6YGbiNDSqQvoAFt7GcYTH2rQT2iAnnb33IglnzQvcjyczJws+jMoPPauvcw1bhG5VxKvL529otm0Nbw==, tarball: https://git.vdb.to/api/packages/cerc-io/npm/%40cerc-io%2Fnitro-util/-/0.1.13/nitro-util-0.1.13.tgz}
     dependencies:
-      '@openzeppelin/contracts': 4.9.3
-      '@statechannels/exit-format': 0.2.0
-      '@typechain/ethers-v5': 9.0.0(@ethersproject/abi@5.7.0)(@ethersproject/bytes@5.7.0)(@ethersproject/providers@5.7.2)(ethers@5.7.2)(typechain@7.0.1)(typescript@5.1.3)
-    transitivePeerDependencies:
-      - '@ethersproject/abi'
-      - '@ethersproject/bytes'
-      - '@ethersproject/providers'
-      - bufferutil
-      - ethers
-      - typechain
-      - typescript
-      - utf-8-validate
-    dev: false
-
-  /@cerc-io/nitro-util@0.1.11(@ethersproject/abi@5.7.0)(@ethersproject/bytes@5.7.0)(@ethersproject/providers@5.7.2)(typechain@7.0.1)(typescript@5.1.3):
-    resolution: {integrity: sha512-DG+mm8ergHuvAcWHy5PSZVsIcDCSQV5/ni2m2NfOLpR3Rz4la5oouYniEoN6z0vJKsQvb7cQ3Wxfeerk8OwcNw==, tarball: https://git.vdb.to/api/packages/cerc-io/npm/%40cerc-io%2Fnitro-util/-/0.1.11/nitro-util-0.1.11.tgz}
-    dependencies:
-      '@cerc-io/nitro-protocol': 2.0.0-alpha.4-ts-port-0.1.3(@ethersproject/abi@5.7.0)(@ethersproject/bytes@5.7.0)(@ethersproject/providers@5.7.2)(ethers@5.7.2)(typechain@7.0.1)(typescript@5.1.3)
       '@cerc-io/ts-channel': 1.0.3-ts-nitro-0.1.1
+      '@statechannels/nitro-protocol': 2.0.0-alpha.5(@ethersproject/abi@5.7.0)(@ethersproject/bytes@5.7.0)(@ethersproject/providers@5.7.2)(ethers@5.7.2)(typechain@7.0.1)(typescript@5.1.3)
       assert: 2.1.0
       debug: 4.3.4(supports-color@8.1.1)
       ethers: 5.7.2
@@ -4606,6 +4588,24 @@ packages:
       lodash: 4.17.21
     transitivePeerDependencies:
       - bufferutil
+      - utf-8-validate
+    dev: false
+
+  /@statechannels/nitro-protocol@2.0.0-alpha.5(@ethersproject/abi@5.7.0)(@ethersproject/bytes@5.7.0)(@ethersproject/providers@5.7.2)(ethers@5.7.2)(typechain@7.0.1)(typescript@5.1.3):
+    resolution: {integrity: sha512-b4rlq0D97MidlKL3MxOsn1Rtl5VzH26xyvVSe8iZXapUdpYfsIH8Nj5PqVki7drFJWVYjVTjwDwc5pvRW8jNbg==}
+    engines: {node: '>=18.5.0'}
+    dependencies:
+      '@openzeppelin/contracts': 4.9.3
+      '@statechannels/exit-format': 0.2.0
+      '@typechain/ethers-v5': 9.0.0(@ethersproject/abi@5.7.0)(@ethersproject/bytes@5.7.0)(@ethersproject/providers@5.7.2)(ethers@5.7.2)(typechain@7.0.1)(typescript@5.1.3)
+    transitivePeerDependencies:
+      - '@ethersproject/abi'
+      - '@ethersproject/bytes'
+      - '@ethersproject/providers'
+      - bufferutil
+      - ethers
+      - typechain
+      - typescript
       - utf-8-validate
     dev: false
 


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/416

- Add `payments` config to `networks` for Nitro payment configuration in each network
- Upgrade `nitro-node` package to version `0.1.13`