### PR TITLE
Implement watcher, indexer and standalone modes with ESM setup

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -22,7 +22,11 @@
     "@typescript-eslint/no-var-requires": "off",
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/no-non-null-assertion": "off",
-    "@typescript-eslint/ban-types": "off"
+    "@typescript-eslint/ban-types": "off",
+    "@typescript-eslint/no-unused-vars": [
+      "error",
+      { "ignoreRestSiblings": true }
+    ]
   },
   "ignorePatterns": ["dist", "node_modules", "generated"]
 }

--- a/docs/pages/api/telemetry/index.ts
+++ b/docs/pages/api/telemetry/index.ts
@@ -1,5 +1,6 @@
-import { Analytics, TrackParams } from "@segment/analytics-node";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { TrackParams } from "@segment/analytics-node";
+import { Analytics } from "@segment/analytics-node";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 if (!process.env.SEGMENT_WRITE_KEY) {
   throw new Error('Missing required environment variable "SEGMENT_WRITE_KEY".');

--- a/examples/ethfs/src/FileStore.ts
+++ b/examples/ethfs/src/FileStore.ts
@@ -1,4 +1,5 @@
-import { fromHex, Hex } from "viem";
+import type { Hex } from "viem";
+import { fromHex } from "viem";
 
 import { ponder } from "@/generated";
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -60,7 +60,6 @@
     "express": "^4.18.1",
     "glob": "^8.1.0",
     "graphql": "^15.3.0",
-    "graphql-http": "^1.22.0",
     "graphql-subscriptions": "^2.0.0",
     "graphql-ws": "^5.14.0",
     "http-terminator": "^3.2.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -74,7 +74,8 @@
     "retry": "^0.13.1",
     "stacktrace-parser": "^0.1.10",
     "tsc-alias": "^1.8.2",
-    "viem": "^1.2.6"
+    "viem": "^1.2.6",
+    "ws": "^8.14.1"
   },
   "devDependencies": {
     "@types/babel__code-frame": "^7.0.3",
@@ -89,6 +90,7 @@
     "@types/react": "^18.0.25",
     "@types/retry": "^0.12.2",
     "@types/supertest": "^2.0.12",
+    "@types/ws": "^8.5.5",
     "@viem/anvil": "^0.0.6",
     "abitype": "^0.8.11",
     "concurrently": "^8.2.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,6 +37,7 @@
     "typecheck": "tsc --project tsconfig.json --noEmit"
   },
   "dependencies": {
+    "@apollo/client": "^3.8.3",
     "@babel/code-frame": "^7.18.6",
     "@cerc-io/nitro-node": "^0.1.13",
     "@cerc-io/nitro-util": "^0.1.13",
@@ -58,6 +59,7 @@
     "glob": "^8.1.0",
     "graphql": "^15.3.0",
     "graphql-http": "^1.22.0",
+    "graphql-ws": "^5.14.0",
     "http-terminator": "^3.2.0",
     "ink": "^3.2.0",
     "kysely": "^0.26.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -60,6 +60,7 @@
     "express": "^4.18.1",
     "glob": "^8.1.0",
     "graphql": "^15.3.0",
+    "graphql-http": "^1.22.0",
     "graphql-subscriptions": "^2.0.0",
     "graphql-ws": "^5.14.0",
     "http-terminator": "^3.2.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -42,7 +42,9 @@
     "@cerc-io/nitro-node": "^0.1.13",
     "@cerc-io/nitro-util": "^0.1.13",
     "@cerc-io/peer": "^0.2.60",
+    "@graphql-tools/schema": "^10.0.0",
     "@jridgewell/trace-mapping": "^0.3.17",
+    "apollo-type-bigint": "^0.1.3",
     "async-mutex": "^0.4.0",
     "better-sqlite3": "^8.7.0",
     "cac": "^6.7.14",
@@ -59,6 +61,7 @@
     "glob": "^8.1.0",
     "graphql": "^15.3.0",
     "graphql-http": "^1.22.0",
+    "graphql-subscriptions": "^2.0.0",
     "graphql-ws": "^5.14.0",
     "http-terminator": "^3.2.0",
     "ink": "^3.2.0",
@@ -78,6 +81,7 @@
     "ws": "^8.14.1"
   },
   "devDependencies": {
+    "@graphql-tools/utils": "^10.0.6",
     "@types/babel__code-frame": "^7.0.3",
     "@types/better-sqlite3": "^7.6.0",
     "@types/cors": "^2.8.12",

--- a/packages/core/src/Ponder.ts
+++ b/packages/core/src/Ponder.ts
@@ -10,7 +10,7 @@ import { buildContracts } from "@/config/contracts.js";
 import { buildDatabase } from "@/config/database.js";
 import { type LogFilter, buildLogFilters } from "@/config/logFilters.js";
 import { type Network, buildNetwork } from "@/config/networks.js";
-import { type Options } from "@/config/options.js";
+import { type Options, AppMode } from "@/config/options.js";
 import { UserErrorService } from "@/errors/service.js";
 import { GqlEventAggregatorService } from "@/event-aggregator/gql-service.js";
 import { InternalEventAggregatorService } from "@/event-aggregator/internal-service.js";
@@ -164,14 +164,9 @@ export class Ponder {
       eventStore: this.eventStore,
     });
 
-    const indexingServerGqlEndpoint = `http://localhost:${this.indexingServerService.port}/graphql`;
+    const gqlClient = createGqlClient(this.common.options.indexerGqlEndpoint);
 
-    const gqlClient = createGqlClient({
-      httpEndpoint: indexingServerGqlEndpoint,
-      subscriptionEndpoint: indexingServerGqlEndpoint,
-    });
-
-    this.eventAggregatorService = options.useGqlIndexing
+    this.eventAggregatorService = this.checkAppMode(AppMode.Watcher)
       ? new GqlEventAggregatorService({
           common,
           gqlClient,
@@ -218,58 +213,77 @@ export class Ponder {
 
     this.registerServiceDependencies();
 
-    // If any of the provided networks do not have a valid RPC url,
-    // kill the app here. This happens here rather than in the constructor because
-    // `ponder codegen` should still be able to if an RPC url is missing. In fact,
-    // that is part of the happy path for `create-ponder`.
-    const networksMissingRpcUrl: Network[] = [];
-    this.networkSyncServices.forEach(({ network }) => {
-      if (!network.rpcUrl) {
-        networksMissingRpcUrl.push(network);
-      }
-    });
-    if (networksMissingRpcUrl.length > 0) {
-      return new Error(
-        `missing RPC URL for networks (${networksMissingRpcUrl.map(
-          (n) => `"${n.name}"`
-        )}). Did you forget to add an RPC URL in .env.local?`
-      );
-    }
-
-    if (this.common.options.useGqlIndexing) {
-      await this.indexingServerService.start();
-
-      assert(this.eventAggregatorService.subscribeToSyncEvents);
-      this.eventAggregatorService.subscribeToSyncEvents();
-    }
-
-    // Start the HTTP server.
-    await this.serverService.start();
-
-    // These files depend only on ponder.config.ts, so can generate once on setup.
-    // Note that loadHandlers depends on the index.ts file being present.
-    this.codegenService.generateAppFile();
-
-    // Note that this must occur before loadSchema and loadHandlers.
-    await this.eventStore.migrateUp();
-
-    // Manually trigger loading schema and handlers. Subsequent loads
-    // are triggered by changes to project files (handled in BuildService).
-    this.buildService.buildSchema();
-    await this.buildService.buildHandlers();
-
-    if (this.paymentService) {
-      // Initialize payment service with Nitro node
-      await this.paymentService.init();
-
-      // Setup payment channel with Nitro nodes
-      const paymentChannelSetupPromises = this.networkSyncServices.map(
-        async ({ network }) => {
-          return this.paymentService!.setupPaymentChannel(network.name);
+    // Setup indexer services if mode is standalone or indexer
+    if (
+      this.checkAppMode(AppMode.Standalone) ||
+      this.checkAppMode(AppMode.Indexer)
+    ) {
+      // If any of the provided networks do not have a valid RPC url,
+      // kill the app here. This happens here rather than in the constructor because
+      // `ponder codegen` should still be able to if an RPC url is missing. In fact,
+      // that is part of the happy path for `create-ponder`.
+      const networksMissingRpcUrl: Network[] = [];
+      this.networkSyncServices.forEach(({ network }) => {
+        if (!network.rpcUrl) {
+          networksMissingRpcUrl.push(network);
         }
-      );
+      });
+      if (networksMissingRpcUrl.length > 0) {
+        return new Error(
+          `missing RPC URL for networks (${networksMissingRpcUrl.map(
+            (n) => `"${n.name}"`
+          )}). Did you forget to add an RPC URL in .env.local?`
+        );
+      }
 
-      await Promise.all(paymentChannelSetupPromises);
+      // Start indexing server if running in indexer mode
+      if (this.checkAppMode(AppMode.Indexer)) {
+        await this.indexingServerService.start();
+
+        // TODO: Remove after adding query for latest checkpoint in indexing server
+        await new Promise((resolve) => setTimeout(resolve, 5000));
+      }
+
+      // Note that this must occur before loadSchema and loadHandlers.
+      await this.eventStore.migrateUp();
+
+      if (this.paymentService) {
+        // Initialize payment service with Nitro node
+        await this.paymentService.init();
+
+        // Setup payment channel with Nitro nodes
+        const paymentChannelSetupPromises = this.networkSyncServices.map(
+          async ({ network }) => {
+            return this.paymentService!.setupPaymentChannel(network.name);
+          }
+        );
+
+        await Promise.all(paymentChannelSetupPromises);
+      }
+    }
+
+    // Setup watcher services if mode is standalone or watcher
+    if (
+      this.checkAppMode(AppMode.Standalone) ||
+      this.checkAppMode(AppMode.Watcher)
+    ) {
+      // Subscribe to Sync service events from indexing server if running in watcher mode
+      if (this.checkAppMode(AppMode.Watcher)) {
+        assert(this.eventAggregatorService.subscribeToSyncEvents);
+        this.eventAggregatorService.subscribeToSyncEvents();
+      }
+
+      // Start the HTTP server.
+      await this.serverService.start();
+
+      // These files depend only on ponder.config.ts, so can generate once on setup.
+      // Note that loadHandlers depends on the index.ts file being present.
+      this.codegenService.generateAppFile();
+
+      // Manually trigger loading schema and handlers. Subsequent loads
+      // are triggered by changes to project files (handled in BuildService).
+      this.buildService.buildSchema();
+      await this.buildService.buildHandlers();
     }
 
     return undefined;
@@ -297,19 +311,25 @@ export class Ponder {
       return await this.kill();
     }
 
-    await Promise.all(
-      this.networkSyncServices.map(
-        async ({ historicalSyncService, realtimeSyncService }) => {
-          const blockNumbers = await realtimeSyncService.setup();
-          await historicalSyncService.setup(blockNumbers);
-          historicalSyncService.start();
+    // Start sync services if running in standalone or indexer mode
+    if (
+      this.checkAppMode(AppMode.Standalone) ||
+      this.checkAppMode(AppMode.Indexer)
+    ) {
+      await Promise.all(
+        this.networkSyncServices.map(
+          async ({ historicalSyncService, realtimeSyncService }) => {
+            const blockNumbers = await realtimeSyncService.setup();
+            await historicalSyncService.setup(blockNumbers);
+            historicalSyncService.start();
 
-          if (!this.paymentService) {
-            realtimeSyncService.start();
+            if (!this.paymentService) {
+              realtimeSyncService.start();
+            }
           }
-        }
-      )
-    );
+        )
+      );
+    }
 
     this.buildService.watch();
   }
@@ -336,19 +356,25 @@ export class Ponder {
       return await this.kill();
     }
 
-    await Promise.all(
-      this.networkSyncServices.map(
-        async ({ historicalSyncService, realtimeSyncService }) => {
-          const blockNumbers = await realtimeSyncService.setup();
-          await historicalSyncService.setup(blockNumbers);
-          historicalSyncService.start();
+    // Start sync services if running in standalone or indexer mode
+    if (
+      this.checkAppMode(AppMode.Standalone) ||
+      this.checkAppMode(AppMode.Indexer)
+    ) {
+      await Promise.all(
+        this.networkSyncServices.map(
+          async ({ historicalSyncService, realtimeSyncService }) => {
+            const blockNumbers = await realtimeSyncService.setup();
+            await historicalSyncService.setup(blockNumbers);
+            historicalSyncService.start();
 
-          if (!this.paymentService) {
-            realtimeSyncService.start();
+            if (!this.paymentService) {
+              realtimeSyncService.start();
+            }
           }
-        }
-      )
-    );
+        )
+      );
+    }
   }
 
   async codegen() {
@@ -405,122 +431,153 @@ export class Ponder {
       await this.kill();
     });
 
-    this.buildService.on("newSchema", async ({ schema, graphqlSchema }) => {
-      this.codegenService.generateAppFile({ schema });
-      this.codegenService.generateSchemaFile({ graphqlSchema });
+    // Register build service listeners if running in standalone or watcher mode
+    if (
+      this.checkAppMode(AppMode.Standalone) ||
+      this.checkAppMode(AppMode.Watcher)
+    ) {
+      this.buildService.on("newSchema", async ({ schema, graphqlSchema }) => {
+        this.codegenService.generateAppFile({ schema });
+        this.codegenService.generateSchemaFile({ graphqlSchema });
 
-      this.serverService.reload({ graphqlSchema });
+        this.serverService.reload({ graphqlSchema });
 
-      await this.eventHandlerService.reset({ schema });
-      await this.eventHandlerService.processEvents();
-    });
-
-    this.buildService.on("newHandlers", async ({ handlers }) => {
-      await this.eventHandlerService.reset({ handlers });
-      await this.eventHandlerService.processEvents();
-    });
-
-    this.networkSyncServices.forEach((networkSyncService) => {
-      const { chainId } = networkSyncService.network;
-      const { historicalSyncService, realtimeSyncService } = networkSyncService;
-
-      historicalSyncService.on("historicalCheckpoint", ({ timestamp }) => {
-        if (this.common.options.useGqlIndexing) {
-          this.indexingServerService.handleNewHistoricalCheckpoint({
-            chainId,
-            timestamp,
-          });
-        } else {
-          this.eventAggregatorService.handleNewHistoricalCheckpoint({
-            chainId,
-            timestamp,
-          });
-        }
-      });
-
-      historicalSyncService.on("syncComplete", () => {
-        if (this.common.options.useGqlIndexing) {
-          this.indexingServerService.handleHistoricalSyncComplete({
-            chainId,
-          });
-        } else {
-          this.eventAggregatorService.handleHistoricalSyncComplete({
-            chainId,
-          });
-        }
-
-        // If payment service is setup, start the realtime sync service after historical sync service.
-        // This will avoid parallel requests to RPC endpoint
-        if (this.paymentService) {
-          realtimeSyncService.start();
-        }
-      });
-
-      realtimeSyncService.on("realtimeCheckpoint", ({ timestamp }) => {
-        if (this.common.options.useGqlIndexing) {
-          this.indexingServerService.handleNewRealtimeCheckpoint({
-            chainId,
-            timestamp,
-          });
-        } else {
-          this.eventAggregatorService.handleNewRealtimeCheckpoint({
-            chainId,
-            timestamp,
-          });
-        }
-      });
-
-      realtimeSyncService.on("finalityCheckpoint", ({ timestamp }) => {
-        if (this.common.options.useGqlIndexing) {
-          this.indexingServerService.handleNewFinalityCheckpoint({
-            chainId,
-            timestamp,
-          });
-        } else {
-          this.eventAggregatorService.handleNewFinalityCheckpoint({
-            chainId,
-            timestamp,
-          });
-        }
-      });
-
-      realtimeSyncService.on("shallowReorg", ({ commonAncestorTimestamp }) => {
-        if (this.common.options.useGqlIndexing) {
-          this.indexingServerService.handleReorg({
-            commonAncestorTimestamp,
-          });
-        } else {
-          this.eventAggregatorService.handleReorg({
-            commonAncestorTimestamp,
-          });
-        }
-      });
-    });
-
-    this.eventAggregatorService.on("newCheckpoint", async () => {
-      await this.eventHandlerService.processEvents();
-    });
-
-    this.eventAggregatorService.on(
-      "reorg",
-      async ({ commonAncestorTimestamp }) => {
-        await this.eventHandlerService.handleReorg({ commonAncestorTimestamp });
+        await this.eventHandlerService.reset({ schema });
         await this.eventHandlerService.processEvents();
-      }
-    );
+      });
 
-    this.eventHandlerService.on("eventsProcessed", ({ toTimestamp }) => {
-      if (this.serverService.isHistoricalIndexingComplete) return;
+      this.buildService.on("newHandlers", async ({ handlers }) => {
+        await this.eventHandlerService.reset({ handlers });
+        await this.eventHandlerService.processEvents();
+      });
+    }
 
-      // If a batch of events are processed AND the historical sync is complete AND
-      // the new toTimestamp is greater than the historical sync completion timestamp,
-      // historical event processing is complete, and the server should begin responding as healthy.
-      if (
-        this.eventAggregatorService.historicalSyncCompletedAt &&
-        toTimestamp >= this.eventAggregatorService.historicalSyncCompletedAt
-      ) {
-        this.serverService.setIsHistoricalIndexingComplete();
-      }
-    });
+    // Register network service listeners if running in standalone or indexer mode
+    if (
+      this.checkAppMode(AppMode.Standalone) ||
+      this.checkAppMode(AppMode.Indexer)
+    ) {
+      this.networkSyncServices.forEach((networkSyncService) => {
+        const { chainId } = networkSyncService.network;
+        const { historicalSyncService, realtimeSyncService } =
+          networkSyncService;
+
+        historicalSyncService.on("historicalCheckpoint", ({ timestamp }) => {
+          if (this.checkAppMode(AppMode.Indexer)) {
+            this.indexingServerService.handleNewHistoricalCheckpoint({
+              chainId,
+              timestamp,
+            });
+          } else {
+            this.eventAggregatorService.handleNewHistoricalCheckpoint({
+              chainId,
+              timestamp,
+            });
+          }
+        });
+
+        historicalSyncService.on("syncComplete", () => {
+          if (this.checkAppMode(AppMode.Indexer)) {
+            this.indexingServerService.handleHistoricalSyncComplete({
+              chainId,
+            });
+          } else {
+            this.eventAggregatorService.handleHistoricalSyncComplete({
+              chainId,
+            });
+          }
+
+          // Check that app is not running in watcher mode
+          if (!this.checkAppMode(AppMode.Watcher)) {
+            // If payment service is setup, start the realtime sync service after historical sync service.
+            // This will avoid parallel requests to RPC endpoint
+            if (this.paymentService) {
+              realtimeSyncService.start();
+            }
+          }
+        });
+
+        realtimeSyncService.on("realtimeCheckpoint", ({ timestamp }) => {
+          if (this.checkAppMode(AppMode.Indexer)) {
+            this.indexingServerService.handleNewRealtimeCheckpoint({
+              chainId,
+              timestamp,
+            });
+          } else {
+            this.eventAggregatorService.handleNewRealtimeCheckpoint({
+              chainId,
+              timestamp,
+            });
+          }
+        });
+
+        realtimeSyncService.on("finalityCheckpoint", ({ timestamp }) => {
+          if (this.checkAppMode(AppMode.Indexer)) {
+            this.indexingServerService.handleNewFinalityCheckpoint({
+              chainId,
+              timestamp,
+            });
+          } else {
+            this.eventAggregatorService.handleNewFinalityCheckpoint({
+              chainId,
+              timestamp,
+            });
+          }
+        });
+
+        realtimeSyncService.on(
+          "shallowReorg",
+          ({ commonAncestorTimestamp }) => {
+            if (this.checkAppMode(AppMode.Indexer)) {
+              this.indexingServerService.handleReorg({
+                commonAncestorTimestamp,
+              });
+            } else {
+              this.eventAggregatorService.handleReorg({
+                commonAncestorTimestamp,
+              });
+            }
+          }
+        );
+      });
+    }
+
+    // Register event aggregator and handler service listeners if running in standalone or watcher mode
+    if (
+      this.checkAppMode(AppMode.Standalone) ||
+      this.checkAppMode(AppMode.Watcher)
+    ) {
+      this.eventAggregatorService.on("newCheckpoint", async () => {
+        await this.eventHandlerService.processEvents();
+      });
+
+      this.eventAggregatorService.on(
+        "reorg",
+        async ({ commonAncestorTimestamp }) => {
+          await this.eventHandlerService.handleReorg({
+            commonAncestorTimestamp,
+          });
+          await this.eventHandlerService.processEvents();
+        }
+      );
+
+      this.eventHandlerService.on("eventsProcessed", ({ toTimestamp }) => {
+        if (this.serverService.isHistoricalIndexingComplete) return;
+
+        // If a batch of events are processed AND the historical sync is complete AND
+        // the new toTimestamp is greater than the historical sync completion timestamp,
+        // historical event processing is complete, and the server should begin responding as healthy.
+        if (
+          this.eventAggregatorService.historicalSyncCompletedAt &&
+          toTimestamp >= this.eventAggregatorService.historicalSyncCompletedAt
+        ) {
+          this.serverService.setIsHistoricalIndexingComplete();
+        }
+      });
+    }
+  }
+
+  private checkAppMode(mode: AppMode) {
+    return this.common.options.mode === mode;
   }
 }

--- a/packages/core/src/Ponder.ts
+++ b/packages/core/src/Ponder.ts
@@ -162,6 +162,7 @@ export class Ponder {
     this.indexingServerService = new IndexingServerService({
       common,
       eventStore: this.eventStore,
+      networks,
     });
 
     const gqlClient = createGqlClient(this.common.options.indexerGqlEndpoint);
@@ -239,9 +240,6 @@ export class Ponder {
       // Start indexing server if running in indexer mode
       if (this.checkAppMode(AppMode.Indexer)) {
         await this.indexingServerService.start();
-
-        // TODO: Remove after adding query for latest checkpoint in indexing server
-        await new Promise((resolve) => setTimeout(resolve, 5000));
       }
 
       // Note that this must occur before loadSchema and loadHandlers.
@@ -270,7 +268,7 @@ export class Ponder {
       // Subscribe to Sync service events from indexing server if running in watcher mode
       if (this.checkAppMode(AppMode.Watcher)) {
         assert(this.eventAggregatorService.subscribeToSyncEvents);
-        this.eventAggregatorService.subscribeToSyncEvents();
+        await this.eventAggregatorService.subscribeToSyncEvents();
       }
 
       // Start the HTTP server.

--- a/packages/core/src/Ponder.ts
+++ b/packages/core/src/Ponder.ts
@@ -439,9 +439,15 @@ export class Ponder {
       });
 
       historicalSyncService.on("syncComplete", () => {
-        this.eventAggregatorService.handleHistoricalSyncComplete({
-          chainId,
-        });
+        if (this.common.options.useGqlIndexing) {
+          this.indexingServerService.handleHistoricalSyncComplete({
+            chainId,
+          });
+        } else {
+          this.eventAggregatorService.handleHistoricalSyncComplete({
+            chainId,
+          });
+        }
 
         // If payment service is setup, start the realtime sync service after historical sync service.
         // This will avoid parallel requests to RPC endpoint
@@ -451,21 +457,43 @@ export class Ponder {
       });
 
       realtimeSyncService.on("realtimeCheckpoint", ({ timestamp }) => {
-        this.eventAggregatorService.handleNewRealtimeCheckpoint({
-          chainId,
-          timestamp,
-        });
+        if (this.common.options.useGqlIndexing) {
+          this.indexingServerService.handleNewRealtimeCheckpoint({
+            chainId,
+            timestamp,
+          });
+        } else {
+          this.eventAggregatorService.handleNewRealtimeCheckpoint({
+            chainId,
+            timestamp,
+          });
+        }
       });
 
       realtimeSyncService.on("finalityCheckpoint", ({ timestamp }) => {
-        this.eventAggregatorService.handleNewFinalityCheckpoint({
-          chainId,
-          timestamp,
-        });
+        if (this.common.options.useGqlIndexing) {
+          this.indexingServerService.handleNewFinalityCheckpoint({
+            chainId,
+            timestamp,
+          });
+        } else {
+          this.eventAggregatorService.handleNewFinalityCheckpoint({
+            chainId,
+            timestamp,
+          });
+        }
       });
 
       realtimeSyncService.on("shallowReorg", ({ commonAncestorTimestamp }) => {
-        this.eventAggregatorService.handleReorg({ commonAncestorTimestamp });
+        if (this.common.options.useGqlIndexing) {
+          this.indexingServerService.handleReorg({
+            commonAncestorTimestamp,
+          });
+        } else {
+          this.eventAggregatorService.handleReorg({
+            commonAncestorTimestamp,
+          });
+        }
       });
     });
 

--- a/packages/core/src/Ponder.ts
+++ b/packages/core/src/Ponder.ts
@@ -128,13 +128,13 @@ export class Ponder {
     this.eventStore =
       eventStore ??
       (database.kind === "sqlite"
-        ? new SqliteEventStore({ db: database.db })
+        ? new SqliteEventStore({ db: database.eventStoreDb })
         : new PostgresEventStore({ pool: database.pool }));
 
     this.userStore =
       userStore ??
       (database.kind === "sqlite"
-        ? new SqliteUserStore({ db: database.db })
+        ? new SqliteUserStore({ db: database.userStoreDb })
         : new PostgresUserStore({ pool: database.pool }));
 
     networks.forEach((network) => {

--- a/packages/core/src/Ponder.ts
+++ b/packages/core/src/Ponder.ts
@@ -11,7 +11,8 @@ import { type LogFilter, buildLogFilters } from "@/config/logFilters.js";
 import { type Network, buildNetwork } from "@/config/networks.js";
 import { type Options } from "@/config/options.js";
 import { UserErrorService } from "@/errors/service.js";
-import { EventAggregatorService } from "@/event-aggregator/service.js";
+import { InternalEventAggregatorService } from "@/event-aggregator/internal-service.js";
+import { type EventAggregatorService } from "@/event-aggregator/service.js";
 import { PostgresEventStore } from "@/event-store/postgres/store.js";
 import { SqliteEventStore } from "@/event-store/sqlite/store.js";
 import { type EventStore } from "@/event-store/store.js";
@@ -153,7 +154,7 @@ export class Ponder {
       });
     });
 
-    this.eventAggregatorService = new EventAggregatorService({
+    this.eventAggregatorService = new InternalEventAggregatorService({
       common,
       eventStore: this.eventStore,
       networks,

--- a/packages/core/src/_test/art-gobblers/app.test.ts
+++ b/packages/core/src/_test/art-gobblers/app.test.ts
@@ -6,7 +6,7 @@ import { type TestContext, afterEach, beforeEach, expect, test } from "vitest";
 import { setupEventStore, setupUserStore } from "@/_test/setup.js";
 import { testNetworkConfig } from "@/_test/utils.js";
 import { buildConfig } from "@/config/config.js";
-import { buildOptions } from "@/config/options.js";
+import { AppMode, buildOptions } from "@/config/options.js";
 import { Ponder } from "@/Ponder.js";
 
 beforeEach((context) => setupEventStore(context));
@@ -23,6 +23,7 @@ const setup = async ({ context }: { context: TestContext }) => {
     cliOptions: {
       rootDir: "./src/_test/art-gobblers/app",
       configFile: "ponder.config.ts",
+      mode: AppMode.Standalone,
     },
   });
   const testOptions = {

--- a/packages/core/src/_test/ens/app.test.ts
+++ b/packages/core/src/_test/ens/app.test.ts
@@ -6,7 +6,7 @@ import { type TestContext, afterEach, beforeEach, expect, test } from "vitest";
 import { setupEventStore, setupUserStore } from "@/_test/setup.js";
 import { testNetworkConfig } from "@/_test/utils.js";
 import { buildConfig } from "@/config/config.js";
-import { buildOptions } from "@/config/options.js";
+import { AppMode, buildOptions } from "@/config/options.js";
 import { Ponder } from "@/Ponder.js";
 
 beforeEach((context) => setupEventStore(context));
@@ -23,6 +23,7 @@ const setup = async ({ context }: { context: TestContext }) => {
     cliOptions: {
       rootDir: "./src/_test/ens/app",
       configFile: "ponder.config.ts",
+      mode: AppMode.Standalone,
     },
   });
   const testOptions = {

--- a/packages/core/src/_test/setup.ts
+++ b/packages/core/src/_test/setup.ts
@@ -6,7 +6,7 @@ import pg from "pg";
 import { type TestContext, beforeEach } from "vitest";
 
 import { patchSqliteDatabase } from "@/config/database.js";
-import { buildOptions } from "@/config/options.js";
+import { AppMode, buildOptions } from "@/config/options.js";
 import { UserErrorService } from "@/errors/service.js";
 import { PostgresEventStore } from "@/event-store/postgres/store.js";
 import { SqliteEventStore } from "@/event-store/sqlite/store.js";
@@ -48,7 +48,7 @@ declare module "vitest" {
 beforeEach((context) => {
   const options = {
     ...buildOptions({
-      cliOptions: { configFile: "", rootDir: "" },
+      cliOptions: { configFile: "", rootDir: "", mode: AppMode.Standalone },
     }),
     telemetryDisabled: true,
   };

--- a/packages/core/src/bin/ponder.ts
+++ b/packages/core/src/bin/ponder.ts
@@ -4,7 +4,7 @@ import dotenv from "dotenv";
 import path from "node:path";
 
 import { buildConfig } from "@/config/config.js";
-import { buildOptions } from "@/config/options.js";
+import { AppMode, buildOptions } from "@/config/options.js";
 import { Ponder } from "@/Ponder.js";
 
 // NOTE: This is a workaround for tsconfig `rootDir` nonsense.
@@ -23,12 +23,16 @@ const cli = cac("ponder")
   })
   .option("--root-dir [path]", `Path to project root directory`, {
     default: ".",
+  })
+  .option("--mode [mode]", `Mode of the Ponder app`, {
+    default: AppMode.Standalone,
   });
 
 export type CliOptions = {
   help?: boolean;
   configFile: string;
   rootDir: string;
+  mode: AppMode;
 };
 
 cli

--- a/packages/core/src/build/service.ts
+++ b/packages/core/src/build/service.ts
@@ -1,6 +1,6 @@
 import chokidar from "chokidar";
 import Emittery from "emittery";
-import { GraphQLSchema } from "graphql";
+import type { GraphQLSchema } from "graphql";
 import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 import path from "node:path";

--- a/packages/core/src/codegen/service.ts
+++ b/packages/core/src/codegen/service.ts
@@ -1,5 +1,6 @@
 import Emittery from "emittery";
-import { GraphQLSchema, printSchema } from "graphql";
+import type { GraphQLSchema } from "graphql";
+import { printSchema } from "graphql";
 import { writeFileSync } from "node:fs";
 import path from "node:path";
 

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -10,8 +10,8 @@ export type ResolvedConfig = {
   database?:
     | {
         kind: "sqlite";
-        /** Path to SQLite database file. Default: `"./.ponder/cache.db"`. */
-        filename?: string;
+        /** Path to SQLite database directory. Default: `"./.ponder/cache"`. */
+        directory?: string;
       }
     | {
         kind: "postgres";
@@ -101,8 +101,8 @@ export type ResolvedConfig = {
   options?: {
     /** Maximum number of seconds to wait for event processing to be complete before responding as healthy. If event processing exceeds this duration, the API may serve incomplete data. Default: `240` (4 minutes). */
     maxHealthcheckDuration?: number;
-    /** Boolean to enable/disable using GQL indexing service */
-    useGqlIndexing?: boolean;
+    /** GQL endpoint of the indexer, required when running app in watcher mode */
+    indexerGqlEndpoint?: string;
   };
   /** Configuration for setting up Nitro node */
   nitro?: {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -101,6 +101,8 @@ export type ResolvedConfig = {
   options?: {
     /** Maximum number of seconds to wait for event processing to be complete before responding as healthy. If event processing exceeds this duration, the API may serve incomplete data. Default: `240` (4 minutes). */
     maxHealthcheckDuration?: number;
+    /** Boolean to enable/disable using GQL indexing service */
+    useGqlIndexing?: boolean;
   };
   /** Configuration for setting up Nitro node */
   nitro?: {

--- a/packages/core/src/config/database.ts
+++ b/packages/core/src/config/database.ts
@@ -96,10 +96,7 @@ export const buildDatabase = ({
 }): Database => {
   let resolvedDatabaseConfig: NonNullable<ResolvedConfig["database"]>;
 
-  const defaultEventStoreSqliteDirectory = path.join(
-    options.ponderDir,
-    "cache"
-  );
+  const defaultSqliteDirectory = path.join(options.ponderDir, "cache");
 
   if (config.database) {
     if (config.database.kind === "postgres") {
@@ -110,8 +107,7 @@ export const buildDatabase = ({
     } else {
       resolvedDatabaseConfig = {
         kind: "sqlite",
-        directory:
-          config.database.directory ?? defaultEventStoreSqliteDirectory,
+        directory: config.database.directory ?? defaultSqliteDirectory,
       };
     }
   } else {
@@ -123,7 +119,7 @@ export const buildDatabase = ({
     } else {
       resolvedDatabaseConfig = {
         kind: "sqlite",
-        directory: defaultEventStoreSqliteDirectory,
+        directory: defaultSqliteDirectory,
       };
     }
   }
@@ -137,9 +133,9 @@ export const buildDatabase = ({
           filename
         );
         ensureDirExists(dbFilePath);
-        const eventStoreRawDb = Sqlite(dbFilePath);
-        eventStoreRawDb.pragma("journal_mode = WAL");
-        return patchSqliteDatabase({ db: eventStoreRawDb });
+        const rawDb = Sqlite(dbFilePath);
+        rawDb.pragma("journal_mode = WAL");
+        return patchSqliteDatabase({ db: rawDb });
       }
     );
 

--- a/packages/core/src/config/database.ts
+++ b/packages/core/src/config/database.ts
@@ -1,4 +1,5 @@
 import Sqlite from "better-sqlite3";
+import assert from "node:assert";
 import path from "node:path";
 import pg from "pg";
 
@@ -10,7 +11,8 @@ import { ensureDirExists } from "@/utils/exists.js";
 
 export interface SqliteDb {
   kind: "sqlite";
-  db: Sqlite.Database;
+  eventStoreDb: Sqlite.Database;
+  userStoreDb: Sqlite.Database;
 }
 
 export interface PostgresDb {
@@ -94,7 +96,10 @@ export const buildDatabase = ({
 }): Database => {
   let resolvedDatabaseConfig: NonNullable<ResolvedConfig["database"]>;
 
-  const defaultSqliteFilename = path.join(options.ponderDir, "cache.db");
+  const defaultEventStoreSqliteDirectory = path.join(
+    options.ponderDir,
+    "cache"
+  );
 
   if (config.database) {
     if (config.database.kind === "postgres") {
@@ -105,7 +110,8 @@ export const buildDatabase = ({
     } else {
       resolvedDatabaseConfig = {
         kind: "sqlite",
-        filename: config.database.filename ?? defaultSqliteFilename,
+        directory:
+          config.database.directory ?? defaultEventStoreSqliteDirectory,
       };
     }
   } else {
@@ -117,19 +123,27 @@ export const buildDatabase = ({
     } else {
       resolvedDatabaseConfig = {
         kind: "sqlite",
-        filename: defaultSqliteFilename,
+        directory: defaultEventStoreSqliteDirectory,
       };
     }
   }
 
   if (resolvedDatabaseConfig.kind === "sqlite") {
-    ensureDirExists(resolvedDatabaseConfig.filename!);
-    const rawDb = Sqlite(resolvedDatabaseConfig.filename!);
-    rawDb.pragma("journal_mode = WAL");
+    const [eventStoreDb, userStoreDb] = ["event-store.db", "user-store.db"].map(
+      (filename) => {
+        assert(resolvedDatabaseConfig.kind === "sqlite");
+        const dbFilePath = path.join(
+          resolvedDatabaseConfig.directory!,
+          filename
+        );
+        ensureDirExists(dbFilePath);
+        const eventStoreRawDb = Sqlite(dbFilePath);
+        eventStoreRawDb.pragma("journal_mode = WAL");
+        return patchSqliteDatabase({ db: eventStoreRawDb });
+      }
+    );
 
-    const db = patchSqliteDatabase({ db: rawDb });
-
-    return { kind: "sqlite", db };
+    return { kind: "sqlite", eventStoreDb, userStoreDb };
   } else {
     const pool = new pg.Pool({
       connectionString: resolvedDatabaseConfig.connectionString,

--- a/packages/core/src/config/options.ts
+++ b/packages/core/src/config/options.ts
@@ -5,6 +5,12 @@ import type { CliOptions } from "@/bin/ponder.js";
 
 import type { ResolvedConfig } from "./config.js";
 
+export enum AppMode {
+  Standalone = "standalone",
+  Indexer = "indexer",
+  Watcher = "watcher",
+}
+
 export type Options = {
   configFile: string;
   schemaFile: string;
@@ -24,7 +30,8 @@ export type Options = {
   logLevel: LevelWithSilent;
   uiEnabled: boolean;
 
-  useGqlIndexing: boolean;
+  mode: AppMode;
+  indexerGqlEndpoint: string;
 };
 
 export const buildOptions = ({
@@ -61,7 +68,9 @@ export const buildOptions = ({
     maxHealthcheckDuration:
       configOptions?.maxHealthcheckDuration ?? railwayHealthcheckTimeout ?? 240,
 
-    useGqlIndexing: configOptions?.useGqlIndexing ?? false,
+    mode: cliOptions.mode,
+    indexerGqlEndpoint:
+      configOptions?.indexerGqlEndpoint ?? "http://localhost:42070/graphql",
 
     telemetryUrl: "https://ponder.sh/api/telemetry",
     telemetryDisabled: Boolean(process.env.PONDER_TELEMETRY_DISABLED),

--- a/packages/core/src/config/options.ts
+++ b/packages/core/src/config/options.ts
@@ -15,6 +15,7 @@ export type Options = {
   logDir: string;
 
   port: number;
+  indexingPort: number;
   maxHealthcheckDuration: number;
   telemetryUrl: string;
   telemetryDisabled: boolean;
@@ -22,6 +23,8 @@ export type Options = {
 
   logLevel: LevelWithSilent;
   uiEnabled: boolean;
+
+  useGqlIndexing: boolean;
 };
 
 export const buildOptions = ({
@@ -54,8 +57,11 @@ export const buildOptions = ({
     logDir: ".ponder/logs",
 
     port: Number(process.env.PORT ?? 42069),
+    indexingPort: Number(process.env.INDEXING_PORT ?? 42070),
     maxHealthcheckDuration:
       configOptions?.maxHealthcheckDuration ?? railwayHealthcheckTimeout ?? 240,
+
+    useGqlIndexing: configOptions?.useGqlIndexing ?? false,
 
     telemetryUrl: "https://ponder.sh/api/telemetry",
     telemetryDisabled: Boolean(process.env.PONDER_TELEMETRY_DISABLED),

--- a/packages/core/src/errors/postgres.ts
+++ b/packages/core/src/errors/postgres.ts
@@ -1,4 +1,4 @@
-import pg from "pg";
+import type pg from "pg";
 
 import { prettyPrint } from "@/utils/print.js";
 

--- a/packages/core/src/errors/service.ts
+++ b/packages/core/src/errors/service.ts
@@ -1,6 +1,6 @@
 import Emittery from "emittery";
 
-import { UserError } from "./user.js";
+import type { UserError } from "./user.js";
 
 type UserErrorEvents = {
   error: { error: UserError };

--- a/packages/core/src/event-aggregator/gql-service.ts
+++ b/packages/core/src/event-aggregator/gql-service.ts
@@ -305,11 +305,18 @@ export class GqlEventAggregatorService extends EventAggregatorService {
       variables,
     });
 
+    // Remove __typename from GQL query result
     const {
       __typename,
-      cursor: { __typename: cursorTypename, ...cursor },
+      cursor: gqlCursor,
       ...metadata
     } = getLogEvents.metadata;
+    let cursor: Cursor | undefined;
+
+    if (gqlCursor) {
+      const { __typename, ...cursorData } = gqlCursor;
+      cursor = cursorData;
+    }
 
     return {
       events: getLogEvents.events.map((event: any) => ({
@@ -360,7 +367,7 @@ export class GqlEventAggregatorService extends EventAggregatorService {
       metadata: {
         pageEndsAtTimestamp: number;
         counts: any[];
-        cursor: Cursor;
+        cursor?: Cursor;
         isLastPage: boolean;
       };
     };

--- a/packages/core/src/event-aggregator/gql-service.ts
+++ b/packages/core/src/event-aggregator/gql-service.ts
@@ -328,7 +328,9 @@ export class GqlEventAggregatorService
   }) => {
     const { gql } = await import("@apollo/client/core");
 
-    const { data: result } = await this.gqlClient.query({
+    const {
+      data: { getLogEvents },
+    } = await this.gqlClient.query({
       query: gql`
         query getLogEvents(
           $fromTimestamp: Int!
@@ -342,14 +344,23 @@ export class GqlEventAggregatorService
           ) {
             events {
               logFilterName
-              log
-              block
-              transaction
+              # log
+              # block
+              # transaction
             }
             metadata {
               pageEndsAtTimestamp
-              counts
-              cursor
+              counts {
+                logFilterName
+                selector
+                count
+              }
+              cursor {
+                timestamp
+                chainId
+                blockNumber
+                logIndex
+              }
               isLastPage
             }
           }
@@ -357,7 +368,8 @@ export class GqlEventAggregatorService
       `,
       variables,
     });
-    return result as {
+
+    return getLogEvents as {
       events: any[];
       metadata: {
         pageEndsAtTimestamp: number;

--- a/packages/core/src/event-aggregator/gql-service.ts
+++ b/packages/core/src/event-aggregator/gql-service.ts
@@ -206,6 +206,56 @@ export class GqlEventAggregatorService
           this.handleNewHistoricalCheckpoint(data.onNewHistoricalCheckpoint);
         }
       ),
+      this.subscribeGql(
+        gql`
+          subscription {
+            onHistoricalSyncComplete {
+              chainId
+            }
+          }
+        `,
+        ({ data }) => {
+          this.handleHistoricalSyncComplete(data.onHistoricalSyncComplete);
+        }
+      ),
+      this.subscribeGql(
+        gql`
+          subscription {
+            onNewRealtimeCheckpoint {
+              chainId
+              timestamp
+            }
+          }
+        `,
+        ({ data }) => {
+          this.handleNewRealtimeCheckpoint(data.onNewRealtimeCheckpoint);
+        }
+      ),
+      this.subscribeGql(
+        gql`
+          subscription {
+            onNewFinalityCheckpoint {
+              chainId
+              timestamp
+            }
+          }
+        `,
+        ({ data }) => {
+          this.handleNewFinalityCheckpoint(data.onNewFinalityCheckpoint);
+        }
+      ),
+      this.subscribeGql(
+        gql`
+          subscription {
+            onReorg {
+              commonAncestorTimestamp
+            }
+          }
+        `,
+        ({ data }) => {
+          this.handleReorg(data.onReorg);
+        }
+      ),
     ];
   }
 

--- a/packages/core/src/event-aggregator/gql-service.ts
+++ b/packages/core/src/event-aggregator/gql-service.ts
@@ -1,10 +1,10 @@
-import {
-  type ApolloClient,
-  type DocumentNode,
-  type NormalizedCacheObject,
-  type ObservableSubscription,
-  gql,
+import type {
+  ApolloClient,
+  DocumentNode,
+  NormalizedCacheObject,
+  ObservableSubscription,
 } from "@apollo/client";
+import apolloClientPkg from "@apollo/client";
 import type { Address } from "viem";
 import { type Hex } from "viem";
 
@@ -16,7 +16,9 @@ import type { Block } from "@/types/block";
 import type { Log } from "@/types/log";
 import type { Transaction } from "@/types/transaction";
 
-import { EventAggregatorService } from "./service";
+import { EventAggregatorService } from "./service.js";
+
+const { gql } = apolloClientPkg;
 
 type Cursor = {
   timestamp: number;
@@ -208,8 +210,6 @@ export class GqlEventAggregatorService extends EventAggregatorService {
       });
     }
 
-    const { gql } = await import("@apollo/client/core");
-
     const {
       data: { getLogEvents },
     } = await this.gqlClient.query({
@@ -385,8 +385,6 @@ export class GqlEventAggregatorService extends EventAggregatorService {
   }
 
   private async fetchHistoricalSync() {
-    const { gql } = await import("@apollo/client/core");
-
     const queryPromises = Object.keys(this.networkCheckpoints).map(
       async (chainId) => {
         const {

--- a/packages/core/src/event-aggregator/gql-service.ts
+++ b/packages/core/src/event-aggregator/gql-service.ts
@@ -1,20 +1,28 @@
+import type { ApolloClient, NormalizedCacheObject } from "@apollo/client";
 import Emittery from "emittery";
+import { type Hex, Address, decodeEventLog } from "viem";
 
-import type { LogFilter } from "@/config/logFilters";
+import type { LogFilterName } from "@/build/handlers";
+import type { LogEventMetadata, LogFilter } from "@/config/logFilters";
 import type { Network } from "@/config/networks";
-import type { EventStore } from "@/event-store/store";
 import type { Common } from "@/Ponder";
+import { formatShortDate } from "@/utils/date";
 
 import type {
   EventAggregatorEvents,
   EventAggregatorMetrics,
   EventAggregatorService,
+  LogEvent,
 } from "./service";
 
 export class GqlEventAggregatorService
   extends Emittery<EventAggregatorEvents>
   implements EventAggregatorService
 {
+  private common: Common;
+  // TODO: Replace with actual type
+  private gqlClient: ApolloClient<NormalizedCacheObject>;
+  private logFilters: LogFilter[];
   private networks: Network[];
 
   // Minimum timestamp at which events are available (across all networks).
@@ -39,17 +47,24 @@ export class GqlEventAggregatorService
   metrics: EventAggregatorMetrics;
 
   constructor({
+    common,
+    gqlClient,
     networks,
+    logFilters,
   }: {
     common: Common;
-    eventStore: EventStore;
+    gqlClient: ApolloClient<NormalizedCacheObject>;
     networks: Network[];
     logFilters: LogFilter[];
   }) {
     super();
 
+    this.common = common;
+    this.logFilters = logFilters;
     this.networks = networks;
     this.metrics = {};
+
+    this.gqlClient = gqlClient;
 
     this.checkpoint = 0;
     this.finalityCheckpoint = 0;
@@ -72,15 +87,172 @@ export class GqlEventAggregatorService
    * @param options.includeLogFilterEvents Map of log filter name -> selector -> ABI event item for which to include full event objects.
    * @returns A promise resolving to an array of log events.
    */
-  async *getEvents() {}
+  async *getEvents({
+    fromTimestamp,
+    toTimestamp,
+    includeLogFilterEvents,
+  }: {
+    fromTimestamp: number;
+    toTimestamp: number;
+    includeLogFilterEvents: {
+      [logFilterName: LogFilterName]:
+        | {
+            bySelector: { [selector: Hex]: LogEventMetadata };
+          }
+        | undefined;
+    };
+  }) {
+    let cursor:
+      | {
+          timestamp: Buffer;
+          chainId: number;
+          blockNumber: Buffer;
+          logIndex: number;
+        }
+      | undefined;
 
-  handleNewHistoricalCheckpoint = () => {};
+    while (true) {
+      const { events, metadata } = await this.getLogEvents({
+        fromTimestamp,
+        toTimestamp,
+        filters: this.logFilters.map((logFilter) => ({
+          name: logFilter.name,
+          chainId: logFilter.filter.chainId,
+          address: logFilter.filter.address,
+          topics: logFilter.filter.topics,
+          fromBlock: logFilter.filter.startBlock,
+          toBlock: logFilter.filter.endBlock,
+          includeEventSelectors: Object.keys(
+            includeLogFilterEvents[logFilter.name]?.bySelector ?? {}
+          ) as Hex[],
+        })),
+        cursor,
+      });
 
-  handleHistoricalSyncComplete = () => {};
+      // Set cursor to fetch next batch of events from indexingClient GQL query
+      cursor = metadata.cursor;
 
-  handleNewRealtimeCheckpoint = () => {};
+      const decodedEvents = (events as any[]).reduce<LogEvent[]>(
+        (acc, event) => {
+          const selector = event.log.topics[0];
+          if (!selector) {
+            throw new Error(
+              `Received an event log with no selector: ${event.log}`
+            );
+          }
 
-  handleNewFinalityCheckpoint = () => {};
+          const logEventMetadata =
+            includeLogFilterEvents[event.logFilterName]?.bySelector[selector];
+          if (!logEventMetadata) {
+            throw new Error(
+              `Metadata for event ${event.logFilterName}:${selector} not found in includeLogFilterEvents`
+            );
+          }
+          const { abiItem, safeName } = logEventMetadata;
+
+          try {
+            const decodedLog = decodeEventLog({
+              abi: [abiItem],
+              data: event.log.data,
+              topics: event.log.topics,
+            });
+
+            acc.push({
+              logFilterName: event.logFilterName,
+              eventName: safeName,
+              params: decodedLog.args || {},
+              log: event.log,
+              block: event.block,
+              transaction: event.transaction,
+            });
+          } catch (err) {
+            // TODO: emit a warning here that a log was not decoded.
+            this.common.logger.error({
+              service: "app",
+              msg: `Unable to decode log (skipping it): ${event.log}`,
+              error: err as Error,
+            });
+          }
+
+          return acc;
+        },
+        []
+      );
+
+      yield { events: decodedEvents, metadata };
+
+      if (metadata.isLastPage) break;
+    }
+  }
+
+  // TODO: Refactor common methods in event aggregator services
+  handleNewHistoricalCheckpoint = ({
+    chainId,
+    timestamp,
+  }: {
+    chainId: number;
+    timestamp: number;
+  }) => {
+    this.networkCheckpoints[chainId].historicalCheckpoint = timestamp;
+
+    this.common.logger.trace({
+      service: "aggregator",
+      msg: `New historical checkpoint at ${timestamp} [${formatShortDate(
+        timestamp
+      )}] (chainId=${chainId})`,
+    });
+
+    this.recalculateCheckpoint();
+  };
+
+  handleHistoricalSyncComplete = ({ chainId }: { chainId: number }) => {
+    this.networkCheckpoints[chainId].isHistoricalSyncComplete = true;
+    this.recalculateCheckpoint();
+
+    // If every network has completed the historical sync, set the metric.
+    const networkCheckpoints = Object.values(this.networkCheckpoints);
+    if (networkCheckpoints.every((n) => n.isHistoricalSyncComplete)) {
+      const maxHistoricalCheckpoint = Math.max(
+        ...networkCheckpoints.map((n) => n.historicalCheckpoint)
+      );
+      this.historicalSyncCompletedAt = maxHistoricalCheckpoint;
+
+      this.common.logger.debug({
+        service: "aggregator",
+        msg: `Completed historical sync across all networks`,
+      });
+    }
+  };
+
+  handleNewRealtimeCheckpoint = ({
+    chainId,
+    timestamp,
+  }: {
+    chainId: number;
+    timestamp: number;
+  }) => {
+    this.networkCheckpoints[chainId].realtimeCheckpoint = timestamp;
+
+    this.common.logger.trace({
+      service: "aggregator",
+      msg: `New realtime checkpoint at ${timestamp} [${formatShortDate(
+        timestamp
+      )}] (chainId=${chainId})`,
+    });
+
+    this.recalculateCheckpoint();
+  };
+
+  handleNewFinalityCheckpoint = ({
+    chainId,
+    timestamp,
+  }: {
+    chainId: number;
+    timestamp: number;
+  }) => {
+    this.networkCheckpoints[chainId].finalityCheckpoint = timestamp;
+    this.recalculateFinalityCheckpoint();
+  };
 
   handleReorg = ({
     commonAncestorTimestamp,
@@ -88,5 +260,111 @@ export class GqlEventAggregatorService
     commonAncestorTimestamp: number;
   }) => {
     this.emit("reorg", { commonAncestorTimestamp });
+  };
+
+  private recalculateCheckpoint = () => {
+    const checkpoints = Object.values(this.networkCheckpoints).map((n) =>
+      n.isHistoricalSyncComplete
+        ? Math.max(n.historicalCheckpoint, n.realtimeCheckpoint)
+        : n.historicalCheckpoint
+    );
+    const newCheckpoint = Math.min(...checkpoints);
+
+    if (newCheckpoint > this.checkpoint) {
+      this.checkpoint = newCheckpoint;
+
+      this.common.logger.trace({
+        service: "aggregator",
+        msg: `New event checkpoint at ${this.checkpoint} [${formatShortDate(
+          this.checkpoint
+        )}]`,
+      });
+
+      this.emit("newCheckpoint", { timestamp: this.checkpoint });
+    }
+  };
+
+  private recalculateFinalityCheckpoint = () => {
+    const newFinalityCheckpoint = Math.min(
+      ...Object.values(this.networkCheckpoints).map((n) => n.finalityCheckpoint)
+    );
+
+    if (newFinalityCheckpoint > this.finalityCheckpoint) {
+      this.finalityCheckpoint = newFinalityCheckpoint;
+
+      this.common.logger.trace({
+        service: "aggregator",
+        msg: `New finality checkpoint at ${
+          this.finalityCheckpoint
+        } [${formatShortDate(this.finalityCheckpoint)}]`,
+      });
+
+      this.emit("newFinalityCheckpoint", {
+        timestamp: this.finalityCheckpoint,
+      });
+    }
+  };
+
+  private getLogEvents = async (variables: {
+    fromTimestamp: number;
+    toTimestamp: number;
+    filters?: {
+      name: string;
+      chainId: number;
+      address?: Address | Address[];
+      topics?: (Hex | Hex[] | null)[];
+      fromBlock?: number;
+      toBlock?: number;
+      includeEventSelectors?: Hex[];
+    }[];
+    cursor:
+      | {
+          timestamp: Buffer;
+          chainId: number;
+          blockNumber: Buffer;
+          logIndex: number;
+        }
+      | undefined;
+  }) => {
+    const { gql } = await import("@apollo/client/core");
+
+    const { data: result } = await this.gqlClient.query({
+      query: gql`
+        query getLogEvents(
+          $fromTimestamp: Int!
+          $toTimestamp: Int!
+          $filters: [Filter!]!
+        ) {
+          getLogEvents(
+            fromTimestamp: $fromTimestamp
+            toTimestamp: $toTimestamp
+            filters: $filters
+          ) {
+            events {
+              logFilterName
+              log
+              block
+              transaction
+            }
+            metadata {
+              pageEndsAtTimestamp
+              counts
+              cursor
+              isLastPage
+            }
+          }
+        }
+      `,
+      variables,
+    });
+    return result as {
+      events: any[];
+      metadata: {
+        pageEndsAtTimestamp: number;
+        counts: any[];
+        cursor: any;
+        isLastPage: boolean;
+      };
+    };
   };
 }

--- a/packages/core/src/event-aggregator/gql-service.ts
+++ b/packages/core/src/event-aggregator/gql-service.ts
@@ -5,7 +5,8 @@ import {
   type ObservableSubscription,
   gql,
 } from "@apollo/client";
-import { type Hex, Address } from "viem";
+import type { Address } from "viem";
+import { type Hex } from "viem";
 
 import type { LogFilterName } from "@/build/handlers";
 import type { LogEventMetadata, LogFilter } from "@/config/logFilters";

--- a/packages/core/src/event-aggregator/gql-service.ts
+++ b/packages/core/src/event-aggregator/gql-service.ts
@@ -1,0 +1,92 @@
+import Emittery from "emittery";
+
+import type { LogFilter } from "@/config/logFilters";
+import type { Network } from "@/config/networks";
+import type { EventStore } from "@/event-store/store";
+import type { Common } from "@/Ponder";
+
+import type {
+  EventAggregatorEvents,
+  EventAggregatorMetrics,
+  EventAggregatorService,
+} from "./service";
+
+export class GqlEventAggregatorService
+  extends Emittery<EventAggregatorEvents>
+  implements EventAggregatorService
+{
+  private networks: Network[];
+
+  // Minimum timestamp at which events are available (across all networks).
+  checkpoint: number;
+  // Minimum finalized timestamp (across all networks).
+  finalityCheckpoint: number;
+
+  // Timestamp at which the historical sync was completed (across all networks).
+  historicalSyncCompletedAt?: number;
+
+  // Per-network event timestamp checkpoints.
+  private networkCheckpoints: Record<
+    number,
+    {
+      isHistoricalSyncComplete: boolean;
+      historicalCheckpoint: number;
+      realtimeCheckpoint: number;
+      finalityCheckpoint: number;
+    }
+  >;
+
+  metrics: EventAggregatorMetrics;
+
+  constructor({
+    networks,
+  }: {
+    common: Common;
+    eventStore: EventStore;
+    networks: Network[];
+    logFilters: LogFilter[];
+  }) {
+    super();
+
+    this.networks = networks;
+    this.metrics = {};
+
+    this.checkpoint = 0;
+    this.finalityCheckpoint = 0;
+
+    this.networkCheckpoints = {};
+    this.networks.forEach((network) => {
+      this.networkCheckpoints[network.chainId] = {
+        isHistoricalSyncComplete: false,
+        historicalCheckpoint: 0,
+        realtimeCheckpoint: 0,
+        finalityCheckpoint: 0,
+      };
+    });
+  }
+
+  /** Fetches events for all registered log filters between the specified timestamps.
+   *
+   * @param options.fromTimestamp Timestamp to start including events (inclusive).
+   * @param options.toTimestamp Timestamp to stop including events (inclusive).
+   * @param options.includeLogFilterEvents Map of log filter name -> selector -> ABI event item for which to include full event objects.
+   * @returns A promise resolving to an array of log events.
+   */
+  async *getEvents() {}
+
+  handleNewHistoricalCheckpoint = () => {};
+
+  handleHistoricalSyncComplete = () => {};
+
+  handleNewRealtimeCheckpoint = () => {};
+
+  handleNewFinalityCheckpoint = () => {};
+
+  handleReorg = ({
+    commonAncestorTimestamp,
+  }: {
+    commonAncestorTimestamp: number;
+  }) => {
+    this.emit("reorg", { commonAncestorTimestamp });
+  };
+}

--- a/packages/core/src/event-aggregator/internal-service.test.ts
+++ b/packages/core/src/event-aggregator/internal-service.test.ts
@@ -7,7 +7,7 @@ import { encodeLogFilterKey } from "@/config/logFilterKey.js";
 import type { LogFilter } from "@/config/logFilters.js";
 import type { Network } from "@/config/networks.js";
 
-import { EventAggregatorService } from "./service.js";
+import { InternalEventAggregatorService } from "./internal-service.js;
 
 beforeEach((context) => setupEventStore(context));
 
@@ -61,7 +61,7 @@ const logFilters: LogFilter[] = [
 test("handleNewHistoricalCheckpoint emits new checkpoint", async (context) => {
   const { common, eventStore } = context;
 
-  const service = new EventAggregatorService({
+  const service = new InternalEventAggregatorService({
     common,
     eventStore,
     logFilters,
@@ -84,7 +84,7 @@ test("handleNewHistoricalCheckpoint emits new checkpoint", async (context) => {
 test("handleNewHistoricalCheckpoint does not emit new checkpoint if not best", async (context) => {
   const { common, eventStore } = context;
 
-  const service = new EventAggregatorService({
+  const service = new InternalEventAggregatorService({
     common,
     eventStore,
     logFilters,
@@ -114,7 +114,7 @@ test("handleNewHistoricalCheckpoint does not emit new checkpoint if not best", a
 test("handleHistoricalSyncComplete sets historicalSyncCompletedAt if final historical sync is complete", async (context) => {
   const { common, eventStore } = context;
 
-  const service = new EventAggregatorService({
+  const service = new InternalEventAggregatorService({
     common,
     eventStore,
     logFilters,
@@ -142,7 +142,7 @@ test("handleHistoricalSyncComplete sets historicalSyncCompletedAt if final histo
 test("handleNewRealtimeCheckpoint does not emit new checkpoint if historical sync is not complete", async (context) => {
   const { common, eventStore } = context;
 
-  const service = new EventAggregatorService({
+  const service = new InternalEventAggregatorService({
     common,
     eventStore,
     logFilters,
@@ -171,7 +171,7 @@ test("handleNewRealtimeCheckpoint does not emit new checkpoint if historical syn
 test("handleNewRealtimeCheckpoint emits new checkpoint if historical sync is complete", async (context) => {
   const { common, eventStore } = context;
 
-  const service = new EventAggregatorService({
+  const service = new InternalEventAggregatorService({
     common,
     eventStore,
     logFilters,
@@ -209,7 +209,7 @@ test("handleNewRealtimeCheckpoint emits new checkpoint if historical sync is com
 test("handleNewFinalityCheckpoint emits newFinalityCheckpoint", async (context) => {
   const { common, eventStore } = context;
 
-  const service = new EventAggregatorService({
+  const service = new InternalEventAggregatorService({
     common,
     eventStore,
     logFilters,
@@ -235,7 +235,7 @@ test("handleNewFinalityCheckpoint emits newFinalityCheckpoint", async (context) 
 test("handleNewFinalityCheckpoint does not emit newFinalityCheckpoint if subsequent event is earlier", async (context) => {
   const { common, eventStore } = context;
 
-  const service = new EventAggregatorService({
+  const service = new InternalEventAggregatorService({
     common,
     eventStore,
     logFilters,
@@ -265,7 +265,7 @@ test("handleNewFinalityCheckpoint does not emit newFinalityCheckpoint if subsequ
 test("handleNewFinalityCheckpoint emits newFinalityCheckpoint if subsequent event is later", async (context) => {
   const { common, eventStore } = context;
 
-  const service = new EventAggregatorService({
+  const service = new InternalEventAggregatorService({
     common,
     eventStore,
     logFilters,

--- a/packages/core/src/event-aggregator/internal-service.test.ts
+++ b/packages/core/src/event-aggregator/internal-service.test.ts
@@ -7,7 +7,7 @@ import { encodeLogFilterKey } from "@/config/logFilterKey.js";
 import type { LogFilter } from "@/config/logFilters.js";
 import type { Network } from "@/config/networks.js";
 
-import { InternalEventAggregatorService } from "./internal-service.js;
+import { InternalEventAggregatorService } from "./internal-service";
 
 beforeEach((context) => setupEventStore(context));
 

--- a/packages/core/src/event-aggregator/internal-service.ts
+++ b/packages/core/src/event-aggregator/internal-service.ts
@@ -1,49 +1,15 @@
-import Emittery from "emittery";
-import { type Hex, decodeEventLog } from "viem";
+import { type Hex } from "viem";
 
 import type { LogFilterName } from "@/build/handlers";
 import type { LogEventMetadata, LogFilter } from "@/config/logFilters";
 import type { Network } from "@/config/networks";
 import type { EventStore } from "@/event-store/store";
 import type { Common } from "@/Ponder";
-import { formatShortDate } from "@/utils/date";
 
-import type {
-  EventAggregatorEvents,
-  EventAggregatorMetrics,
-  EventAggregatorService,
-  LogEvent,
-} from "./service";
+import { EventAggregatorService } from "./service";
 
-export class InternalEventAggregatorService
-  extends Emittery<EventAggregatorEvents>
-  implements EventAggregatorService
-{
-  private common: Common;
+export class InternalEventAggregatorService extends EventAggregatorService {
   private eventStore: EventStore;
-  private logFilters: LogFilter[];
-  private networks: Network[];
-
-  // Minimum timestamp at which events are available (across all networks).
-  checkpoint: number;
-  // Minimum finalized timestamp (across all networks).
-  finalityCheckpoint: number;
-
-  // Timestamp at which the historical sync was completed (across all networks).
-  historicalSyncCompletedAt?: number;
-
-  // Per-network event timestamp checkpoints.
-  private networkCheckpoints: Record<
-    number,
-    {
-      isHistoricalSyncComplete: boolean;
-      historicalCheckpoint: number;
-      realtimeCheckpoint: number;
-      finalityCheckpoint: number;
-    }
-  >;
-
-  metrics: EventAggregatorMetrics;
 
   constructor({
     common,
@@ -56,26 +22,13 @@ export class InternalEventAggregatorService
     networks: Network[];
     logFilters: LogFilter[];
   }) {
-    super();
-
-    this.common = common;
-    this.eventStore = eventStore;
-    this.logFilters = logFilters;
-    this.networks = networks;
-    this.metrics = {};
-
-    this.checkpoint = 0;
-    this.finalityCheckpoint = 0;
-
-    this.networkCheckpoints = {};
-    this.networks.forEach((network) => {
-      this.networkCheckpoints[network.chainId] = {
-        isHistoricalSyncComplete: false,
-        historicalCheckpoint: 0,
-        realtimeCheckpoint: 0,
-        finalityCheckpoint: 0,
-      };
+    super({
+      common,
+      networks,
+      logFilters,
     });
+
+    this.eventStore = eventStore;
   }
 
   /** Fetches events for all registered log filters between the specified timestamps.
@@ -119,174 +72,9 @@ export class InternalEventAggregatorService
     for await (const page of iterator) {
       const { events, metadata } = page;
 
-      const decodedEvents = events.reduce<LogEvent[]>((acc, event) => {
-        const selector = event.log.topics[0];
-        if (!selector) {
-          throw new Error(
-            `Received an event log with no selector: ${event.log}`
-          );
-        }
-
-        const logEventMetadata =
-          includeLogFilterEvents[event.logFilterName]?.bySelector[selector];
-        if (!logEventMetadata) {
-          throw new Error(
-            `Metadata for event ${event.logFilterName}:${selector} not found in includeLogFilterEvents`
-          );
-        }
-        const { abiItem, safeName } = logEventMetadata;
-
-        try {
-          const decodedLog = decodeEventLog({
-            abi: [abiItem],
-            data: event.log.data,
-            topics: event.log.topics,
-          });
-
-          acc.push({
-            logFilterName: event.logFilterName,
-            eventName: safeName,
-            params: decodedLog.args || {},
-            log: event.log,
-            block: event.block,
-            transaction: event.transaction,
-          });
-        } catch (err) {
-          // TODO: emit a warning here that a log was not decoded.
-          this.common.logger.error({
-            service: "app",
-            msg: `Unable to decode log (skipping it): ${event.log}`,
-            error: err as Error,
-          });
-        }
-
-        return acc;
-      }, []);
+      const decodedEvents = this.decodeEvents(events, includeLogFilterEvents);
 
       yield { events: decodedEvents, metadata };
     }
   }
-
-  kill() {
-    this.clearListeners();
-  }
-
-  handleNewHistoricalCheckpoint = ({
-    chainId,
-    timestamp,
-  }: {
-    chainId: number;
-    timestamp: number;
-  }) => {
-    this.networkCheckpoints[chainId].historicalCheckpoint = timestamp;
-
-    this.common.logger.trace({
-      service: "aggregator",
-      msg: `New historical checkpoint at ${timestamp} [${formatShortDate(
-        timestamp
-      )}] (chainId=${chainId})`,
-    });
-
-    this.recalculateCheckpoint();
-  };
-
-  handleHistoricalSyncComplete = ({ chainId }: { chainId: number }) => {
-    this.networkCheckpoints[chainId].isHistoricalSyncComplete = true;
-    this.recalculateCheckpoint();
-
-    // If every network has completed the historical sync, set the metric.
-    const networkCheckpoints = Object.values(this.networkCheckpoints);
-    if (networkCheckpoints.every((n) => n.isHistoricalSyncComplete)) {
-      const maxHistoricalCheckpoint = Math.max(
-        ...networkCheckpoints.map((n) => n.historicalCheckpoint)
-      );
-      this.historicalSyncCompletedAt = maxHistoricalCheckpoint;
-
-      this.common.logger.debug({
-        service: "aggregator",
-        msg: `Completed historical sync across all networks`,
-      });
-    }
-  };
-
-  handleNewRealtimeCheckpoint = ({
-    chainId,
-    timestamp,
-  }: {
-    chainId: number;
-    timestamp: number;
-  }) => {
-    this.networkCheckpoints[chainId].realtimeCheckpoint = timestamp;
-
-    this.common.logger.trace({
-      service: "aggregator",
-      msg: `New realtime checkpoint at ${timestamp} [${formatShortDate(
-        timestamp
-      )}] (chainId=${chainId})`,
-    });
-
-    this.recalculateCheckpoint();
-  };
-
-  handleNewFinalityCheckpoint = ({
-    chainId,
-    timestamp,
-  }: {
-    chainId: number;
-    timestamp: number;
-  }) => {
-    this.networkCheckpoints[chainId].finalityCheckpoint = timestamp;
-    this.recalculateFinalityCheckpoint();
-  };
-
-  handleReorg = ({
-    commonAncestorTimestamp,
-  }: {
-    commonAncestorTimestamp: number;
-  }) => {
-    this.emit("reorg", { commonAncestorTimestamp });
-  };
-
-  private recalculateCheckpoint = () => {
-    const checkpoints = Object.values(this.networkCheckpoints).map((n) =>
-      n.isHistoricalSyncComplete
-        ? Math.max(n.historicalCheckpoint, n.realtimeCheckpoint)
-        : n.historicalCheckpoint
-    );
-    const newCheckpoint = Math.min(...checkpoints);
-
-    if (newCheckpoint > this.checkpoint) {
-      this.checkpoint = newCheckpoint;
-
-      this.common.logger.trace({
-        service: "aggregator",
-        msg: `New event checkpoint at ${this.checkpoint} [${formatShortDate(
-          this.checkpoint
-        )}]`,
-      });
-
-      this.emit("newCheckpoint", { timestamp: this.checkpoint });
-    }
-  };
-
-  private recalculateFinalityCheckpoint = () => {
-    const newFinalityCheckpoint = Math.min(
-      ...Object.values(this.networkCheckpoints).map((n) => n.finalityCheckpoint)
-    );
-
-    if (newFinalityCheckpoint > this.finalityCheckpoint) {
-      this.finalityCheckpoint = newFinalityCheckpoint;
-
-      this.common.logger.trace({
-        service: "aggregator",
-        msg: `New finality checkpoint at ${
-          this.finalityCheckpoint
-        } [${formatShortDate(this.finalityCheckpoint)}]`,
-      });
-
-      this.emit("newFinalityCheckpoint", {
-        timestamp: this.finalityCheckpoint,
-      });
-    }
-  };
 }

--- a/packages/core/src/event-aggregator/internal-service.ts
+++ b/packages/core/src/event-aggregator/internal-service.ts
@@ -1,0 +1,288 @@
+import Emittery from "emittery";
+import { type Hex, decodeEventLog } from "viem";
+
+import type { LogFilterName } from "@/build/handlers";
+import type { LogEventMetadata, LogFilter } from "@/config/logFilters";
+import type { Network } from "@/config/networks";
+import type { EventStore } from "@/event-store/store";
+import type { Common } from "@/Ponder";
+import { formatShortDate } from "@/utils/date";
+
+import type {
+  EventAggregatorEvents,
+  EventAggregatorMetrics,
+  EventAggregatorService,
+  LogEvent,
+} from "./service";
+
+export class InternalEventAggregatorService
+  extends Emittery<EventAggregatorEvents>
+  implements EventAggregatorService
+{
+  private common: Common;
+  private eventStore: EventStore;
+  private logFilters: LogFilter[];
+  private networks: Network[];
+
+  // Minimum timestamp at which events are available (across all networks).
+  checkpoint: number;
+  // Minimum finalized timestamp (across all networks).
+  finalityCheckpoint: number;
+
+  // Timestamp at which the historical sync was completed (across all networks).
+  historicalSyncCompletedAt?: number;
+
+  // Per-network event timestamp checkpoints.
+  private networkCheckpoints: Record<
+    number,
+    {
+      isHistoricalSyncComplete: boolean;
+      historicalCheckpoint: number;
+      realtimeCheckpoint: number;
+      finalityCheckpoint: number;
+    }
+  >;
+
+  metrics: EventAggregatorMetrics;
+
+  constructor({
+    common,
+    eventStore,
+    networks,
+    logFilters,
+  }: {
+    common: Common;
+    eventStore: EventStore;
+    networks: Network[];
+    logFilters: LogFilter[];
+  }) {
+    super();
+
+    this.common = common;
+    this.eventStore = eventStore;
+    this.logFilters = logFilters;
+    this.networks = networks;
+    this.metrics = {};
+
+    this.checkpoint = 0;
+    this.finalityCheckpoint = 0;
+
+    this.networkCheckpoints = {};
+    this.networks.forEach((network) => {
+      this.networkCheckpoints[network.chainId] = {
+        isHistoricalSyncComplete: false,
+        historicalCheckpoint: 0,
+        realtimeCheckpoint: 0,
+        finalityCheckpoint: 0,
+      };
+    });
+  }
+
+  /** Fetches events for all registered log filters between the specified timestamps.
+   *
+   * @param options.fromTimestamp Timestamp to start including events (inclusive).
+   * @param options.toTimestamp Timestamp to stop including events (inclusive).
+   * @param options.includeLogFilterEvents Map of log filter name -> selector -> ABI event item for which to include full event objects.
+   * @returns A promise resolving to an array of log events.
+   */
+  async *getEvents({
+    fromTimestamp,
+    toTimestamp,
+    includeLogFilterEvents,
+  }: {
+    fromTimestamp: number;
+    toTimestamp: number;
+    includeLogFilterEvents: {
+      [logFilterName: LogFilterName]:
+        | {
+            bySelector: { [selector: Hex]: LogEventMetadata };
+          }
+        | undefined;
+    };
+  }) {
+    const iterator = this.eventStore.getLogEvents({
+      fromTimestamp,
+      toTimestamp,
+      filters: this.logFilters.map((logFilter) => ({
+        name: logFilter.name,
+        chainId: logFilter.filter.chainId,
+        address: logFilter.filter.address,
+        topics: logFilter.filter.topics,
+        fromBlock: logFilter.filter.startBlock,
+        toBlock: logFilter.filter.endBlock,
+        includeEventSelectors: Object.keys(
+          includeLogFilterEvents[logFilter.name]?.bySelector ?? {}
+        ) as Hex[],
+      })),
+    });
+
+    for await (const page of iterator) {
+      const { events, metadata } = page;
+
+      const decodedEvents = events.reduce<LogEvent[]>((acc, event) => {
+        const selector = event.log.topics[0];
+        if (!selector) {
+          throw new Error(
+            `Received an event log with no selector: ${event.log}`
+          );
+        }
+
+        const logEventMetadata =
+          includeLogFilterEvents[event.logFilterName]?.bySelector[selector];
+        if (!logEventMetadata) {
+          throw new Error(
+            `Metadata for event ${event.logFilterName}:${selector} not found in includeLogFilterEvents`
+          );
+        }
+        const { abiItem, safeName } = logEventMetadata;
+
+        try {
+          const decodedLog = decodeEventLog({
+            abi: [abiItem],
+            data: event.log.data,
+            topics: event.log.topics,
+          });
+
+          acc.push({
+            logFilterName: event.logFilterName,
+            eventName: safeName,
+            params: decodedLog.args || {},
+            log: event.log,
+            block: event.block,
+            transaction: event.transaction,
+          });
+        } catch (err) {
+          // TODO: emit a warning here that a log was not decoded.
+          this.common.logger.error({
+            service: "app",
+            msg: `Unable to decode log (skipping it): ${event.log}`,
+            error: err as Error,
+          });
+        }
+
+        return acc;
+      }, []);
+
+      yield { events: decodedEvents, metadata };
+    }
+  }
+
+  handleNewHistoricalCheckpoint = ({
+    chainId,
+    timestamp,
+  }: {
+    chainId: number;
+    timestamp: number;
+  }) => {
+    this.networkCheckpoints[chainId].historicalCheckpoint = timestamp;
+
+    this.common.logger.trace({
+      service: "aggregator",
+      msg: `New historical checkpoint at ${timestamp} [${formatShortDate(
+        timestamp
+      )}] (chainId=${chainId})`,
+    });
+
+    this.recalculateCheckpoint();
+  };
+
+  handleHistoricalSyncComplete = ({ chainId }: { chainId: number }) => {
+    this.networkCheckpoints[chainId].isHistoricalSyncComplete = true;
+    this.recalculateCheckpoint();
+
+    // If every network has completed the historical sync, set the metric.
+    const networkCheckpoints = Object.values(this.networkCheckpoints);
+    if (networkCheckpoints.every((n) => n.isHistoricalSyncComplete)) {
+      const maxHistoricalCheckpoint = Math.max(
+        ...networkCheckpoints.map((n) => n.historicalCheckpoint)
+      );
+      this.historicalSyncCompletedAt = maxHistoricalCheckpoint;
+
+      this.common.logger.debug({
+        service: "aggregator",
+        msg: `Completed historical sync across all networks`,
+      });
+    }
+  };
+
+  handleNewRealtimeCheckpoint = ({
+    chainId,
+    timestamp,
+  }: {
+    chainId: number;
+    timestamp: number;
+  }) => {
+    this.networkCheckpoints[chainId].realtimeCheckpoint = timestamp;
+
+    this.common.logger.trace({
+      service: "aggregator",
+      msg: `New realtime checkpoint at ${timestamp} [${formatShortDate(
+        timestamp
+      )}] (chainId=${chainId})`,
+    });
+
+    this.recalculateCheckpoint();
+  };
+
+  handleNewFinalityCheckpoint = ({
+    chainId,
+    timestamp,
+  }: {
+    chainId: number;
+    timestamp: number;
+  }) => {
+    this.networkCheckpoints[chainId].finalityCheckpoint = timestamp;
+    this.recalculateFinalityCheckpoint();
+  };
+
+  handleReorg = ({
+    commonAncestorTimestamp,
+  }: {
+    commonAncestorTimestamp: number;
+  }) => {
+    this.emit("reorg", { commonAncestorTimestamp });
+  };
+
+  private recalculateCheckpoint = () => {
+    const checkpoints = Object.values(this.networkCheckpoints).map((n) =>
+      n.isHistoricalSyncComplete
+        ? Math.max(n.historicalCheckpoint, n.realtimeCheckpoint)
+        : n.historicalCheckpoint
+    );
+    const newCheckpoint = Math.min(...checkpoints);
+
+    if (newCheckpoint > this.checkpoint) {
+      this.checkpoint = newCheckpoint;
+
+      this.common.logger.trace({
+        service: "aggregator",
+        msg: `New event checkpoint at ${this.checkpoint} [${formatShortDate(
+          this.checkpoint
+        )}]`,
+      });
+
+      this.emit("newCheckpoint", { timestamp: this.checkpoint });
+    }
+  };
+
+  private recalculateFinalityCheckpoint = () => {
+    const newFinalityCheckpoint = Math.min(
+      ...Object.values(this.networkCheckpoints).map((n) => n.finalityCheckpoint)
+    );
+
+    if (newFinalityCheckpoint > this.finalityCheckpoint) {
+      this.finalityCheckpoint = newFinalityCheckpoint;
+
+      this.common.logger.trace({
+        service: "aggregator",
+        msg: `New finality checkpoint at ${
+          this.finalityCheckpoint
+        } [${formatShortDate(this.finalityCheckpoint)}]`,
+      });
+
+      this.emit("newFinalityCheckpoint", {
+        timestamp: this.finalityCheckpoint,
+      });
+    }
+  };
+}

--- a/packages/core/src/event-aggregator/internal-service.ts
+++ b/packages/core/src/event-aggregator/internal-service.ts
@@ -6,7 +6,7 @@ import type { Network } from "@/config/networks";
 import type { EventStore } from "@/event-store/store";
 import type { Common } from "@/Ponder";
 
-import { EventAggregatorService } from "./service";
+import { EventAggregatorService } from "./service.js";
 
 export class InternalEventAggregatorService extends EventAggregatorService {
   private eventStore: EventStore;

--- a/packages/core/src/event-aggregator/internal-service.ts
+++ b/packages/core/src/event-aggregator/internal-service.ts
@@ -167,6 +167,10 @@ export class InternalEventAggregatorService
     }
   }
 
+  kill() {
+    this.clearListeners();
+  }
+
   handleNewHistoricalCheckpoint = ({
     chainId,
     timestamp,

--- a/packages/core/src/event-aggregator/service.ts
+++ b/packages/core/src/event-aggregator/service.ts
@@ -52,7 +52,7 @@ export abstract class EventAggregatorService extends Emittery<EventAggregatorEve
   historicalSyncCompletedAt?: number;
 
   // Per-network event timestamp checkpoints.
-  private networkCheckpoints: Record<
+  protected networkCheckpoints: Record<
     number,
     {
       isHistoricalSyncComplete: boolean;
@@ -127,7 +127,7 @@ export abstract class EventAggregatorService extends Emittery<EventAggregatorEve
     };
   }>;
 
-  subscribeToSyncEvents?(): void;
+  subscribeToSyncEvents?(): Promise<void>;
 
   kill() {
     this.clearListeners();

--- a/packages/core/src/event-aggregator/service.ts
+++ b/packages/core/src/event-aggregator/service.ts
@@ -1,15 +1,11 @@
-import Emittery from "emittery";
-import { type Hex, decodeEventLog } from "viem";
+import type Emittery from "emittery";
+import type { Hex } from "viem";
 
 import type { LogFilterName } from "@/build/handlers.js";
-import type { LogEventMetadata, LogFilter } from "@/config/logFilters.js";
-import type { Network } from "@/config/networks.js";
-import type { EventStore } from "@/event-store/store.js";
-import type { Common } from "@/Ponder.js";
+import type { LogEventMetadata } from "@/config/logFilters.js";
 import type { Block } from "@/types/block.js";
 import type { Log } from "@/types/log.js";
 import type { Transaction } from "@/types/transaction.js";
-import { formatShortDate } from "@/utils/date.js";
 
 export type LogEvent = {
   logFilterName: string;
@@ -20,7 +16,7 @@ export type LogEvent = {
   transaction: Transaction;
 };
 
-type EventAggregatorEvents = {
+export type EventAggregatorEvents = {
   /**
    * Emitted when a new event checkpoint is reached. This is the minimum timestamp
    * at which events are available across all registered networks.
@@ -37,14 +33,10 @@ type EventAggregatorEvents = {
   reorg: { commonAncestorTimestamp: number };
 };
 
-type EventAggregatorMetrics = {};
+export type EventAggregatorMetrics = {};
 
-export class EventAggregatorService extends Emittery<EventAggregatorEvents> {
-  private common: Common;
-  private eventStore: EventStore;
-  private logFilters: LogFilter[];
-  private networks: Network[];
-
+export interface EventAggregatorService
+  extends Emittery<EventAggregatorEvents> {
   // Minimum timestamp at which events are available (across all networks).
   checkpoint: number;
   // Minimum finalized timestamp (across all networks).
@@ -53,51 +45,7 @@ export class EventAggregatorService extends Emittery<EventAggregatorEvents> {
   // Timestamp at which the historical sync was completed (across all networks).
   historicalSyncCompletedAt?: number;
 
-  // Per-network event timestamp checkpoints.
-  private networkCheckpoints: Record<
-    number,
-    {
-      isHistoricalSyncComplete: boolean;
-      historicalCheckpoint: number;
-      realtimeCheckpoint: number;
-      finalityCheckpoint: number;
-    }
-  >;
-
   metrics: EventAggregatorMetrics;
-
-  constructor({
-    common,
-    eventStore,
-    networks,
-    logFilters,
-  }: {
-    common: Common;
-    eventStore: EventStore;
-    networks: Network[];
-    logFilters: LogFilter[];
-  }) {
-    super();
-
-    this.common = common;
-    this.eventStore = eventStore;
-    this.logFilters = logFilters;
-    this.networks = networks;
-    this.metrics = {};
-
-    this.checkpoint = 0;
-    this.finalityCheckpoint = 0;
-
-    this.networkCheckpoints = {};
-    this.networks.forEach((network) => {
-      this.networkCheckpoints[network.chainId] = {
-        isHistoricalSyncComplete: false,
-        historicalCheckpoint: 0,
-        realtimeCheckpoint: 0,
-        finalityCheckpoint: 0,
-      };
-    });
-  }
 
   /** Fetches events for all registered log filters between the specified timestamps.
    *
@@ -106,7 +54,8 @@ export class EventAggregatorService extends Emittery<EventAggregatorEvents> {
    * @param options.includeLogFilterEvents Map of log filter name -> selector -> ABI event item for which to include full event objects.
    * @returns A promise resolving to an array of log events.
    */
-  async *getEvents({
+  // TODO: Remove void from return type
+  getEvents({
     fromTimestamp,
     toTimestamp,
     includeLogFilterEvents,
@@ -120,190 +69,47 @@ export class EventAggregatorService extends Emittery<EventAggregatorEvents> {
           }
         | undefined;
     };
-  }) {
-    const iterator = this.eventStore.getLogEvents({
-      fromTimestamp,
-      toTimestamp,
-      filters: this.logFilters.map((logFilter) => ({
-        name: logFilter.name,
-        chainId: logFilter.filter.chainId,
-        address: logFilter.filter.address,
-        topics: logFilter.filter.topics,
-        fromBlock: logFilter.filter.startBlock,
-        toBlock: logFilter.filter.endBlock,
-        includeEventSelectors: Object.keys(
-          includeLogFilterEvents[logFilter.name]?.bySelector ?? {}
-        ) as Hex[],
-      })),
-    });
+  }): AsyncGenerator<{
+    events: LogEvent[];
+    metadata: {
+      pageEndsAtTimestamp: number;
+      counts: {
+        logFilterName: string;
+        selector: Hex;
+        count: number;
+      }[];
+    };
+  }> | void;
 
-    for await (const page of iterator) {
-      const { events, metadata } = page;
-
-      const decodedEvents = events.reduce<LogEvent[]>((acc, event) => {
-        const selector = event.log.topics[0];
-        if (!selector) {
-          throw new Error(
-            `Received an event log with no selector: ${event.log}`
-          );
-        }
-
-        const logEventMetadata =
-          includeLogFilterEvents[event.logFilterName]?.bySelector[selector];
-        if (!logEventMetadata) {
-          throw new Error(
-            `Metadata for event ${event.logFilterName}:${selector} not found in includeLogFilterEvents`
-          );
-        }
-        const { abiItem, safeName } = logEventMetadata;
-
-        try {
-          const decodedLog = decodeEventLog({
-            abi: [abiItem],
-            data: event.log.data,
-            topics: event.log.topics,
-          });
-
-          acc.push({
-            logFilterName: event.logFilterName,
-            eventName: safeName,
-            params: decodedLog.args || {},
-            log: event.log,
-            block: event.block,
-            transaction: event.transaction,
-          });
-        } catch (err) {
-          // TODO: emit a warning here that a log was not decoded.
-          this.common.logger.error({
-            service: "app",
-            msg: `Unable to decode log (skipping it): ${event.log}`,
-            error: err as Error,
-          });
-        }
-
-        return acc;
-      }, []);
-
-      yield { events: decodedEvents, metadata };
-    }
-  }
-
-  handleNewHistoricalCheckpoint = ({
+  handleNewHistoricalCheckpoint({
     chainId,
     timestamp,
   }: {
     chainId: number;
     timestamp: number;
-  }) => {
-    this.networkCheckpoints[chainId].historicalCheckpoint = timestamp;
+  }): void;
 
-    this.common.logger.trace({
-      service: "aggregator",
-      msg: `New historical checkpoint at ${timestamp} [${formatShortDate(
-        timestamp
-      )}] (chainId=${chainId})`,
-    });
+  handleHistoricalSyncComplete({ chainId }: { chainId: number }): void;
 
-    this.recalculateCheckpoint();
-  };
-
-  handleHistoricalSyncComplete = ({ chainId }: { chainId: number }) => {
-    this.networkCheckpoints[chainId].isHistoricalSyncComplete = true;
-    this.recalculateCheckpoint();
-
-    // If every network has completed the historical sync, set the metric.
-    const networkCheckpoints = Object.values(this.networkCheckpoints);
-    if (networkCheckpoints.every((n) => n.isHistoricalSyncComplete)) {
-      const maxHistoricalCheckpoint = Math.max(
-        ...networkCheckpoints.map((n) => n.historicalCheckpoint)
-      );
-      this.historicalSyncCompletedAt = maxHistoricalCheckpoint;
-
-      this.common.logger.debug({
-        service: "aggregator",
-        msg: `Completed historical sync across all networks`,
-      });
-    }
-  };
-
-  handleNewRealtimeCheckpoint = ({
+  handleNewRealtimeCheckpoint({
     chainId,
     timestamp,
   }: {
     chainId: number;
     timestamp: number;
-  }) => {
-    this.networkCheckpoints[chainId].realtimeCheckpoint = timestamp;
+  }): void;
 
-    this.common.logger.trace({
-      service: "aggregator",
-      msg: `New realtime checkpoint at ${timestamp} [${formatShortDate(
-        timestamp
-      )}] (chainId=${chainId})`,
-    });
-
-    this.recalculateCheckpoint();
-  };
-
-  handleNewFinalityCheckpoint = ({
+  handleNewFinalityCheckpoint({
     chainId,
     timestamp,
   }: {
     chainId: number;
     timestamp: number;
-  }) => {
-    this.networkCheckpoints[chainId].finalityCheckpoint = timestamp;
-    this.recalculateFinalityCheckpoint();
-  };
+  }): void;
 
-  handleReorg = ({
+  handleReorg({
     commonAncestorTimestamp,
   }: {
     commonAncestorTimestamp: number;
-  }) => {
-    this.emit("reorg", { commonAncestorTimestamp });
-  };
-
-  private recalculateCheckpoint = () => {
-    const checkpoints = Object.values(this.networkCheckpoints).map((n) =>
-      n.isHistoricalSyncComplete
-        ? Math.max(n.historicalCheckpoint, n.realtimeCheckpoint)
-        : n.historicalCheckpoint
-    );
-    const newCheckpoint = Math.min(...checkpoints);
-
-    if (newCheckpoint > this.checkpoint) {
-      this.checkpoint = newCheckpoint;
-
-      this.common.logger.trace({
-        service: "aggregator",
-        msg: `New event checkpoint at ${this.checkpoint} [${formatShortDate(
-          this.checkpoint
-        )}]`,
-      });
-
-      this.emit("newCheckpoint", { timestamp: this.checkpoint });
-    }
-  };
-
-  private recalculateFinalityCheckpoint = () => {
-    const newFinalityCheckpoint = Math.min(
-      ...Object.values(this.networkCheckpoints).map((n) => n.finalityCheckpoint)
-    );
-
-    if (newFinalityCheckpoint > this.finalityCheckpoint) {
-      this.finalityCheckpoint = newFinalityCheckpoint;
-
-      this.common.logger.trace({
-        service: "aggregator",
-        msg: `New finality checkpoint at ${
-          this.finalityCheckpoint
-        } [${formatShortDate(this.finalityCheckpoint)}]`,
-      });
-
-      this.emit("newFinalityCheckpoint", {
-        timestamp: this.finalityCheckpoint,
-      });
-    }
-  };
+  }): void;
 }

--- a/packages/core/src/event-aggregator/service.ts
+++ b/packages/core/src/event-aggregator/service.ts
@@ -1,11 +1,14 @@
-import type Emittery from "emittery";
-import type { Hex } from "viem";
+import Emittery from "emittery";
+import { type Hex, decodeEventLog } from "viem";
 
 import type { LogFilterName } from "@/build/handlers.js";
-import type { LogEventMetadata } from "@/config/logFilters.js";
+import type { LogEventMetadata, LogFilter } from "@/config/logFilters.js";
+import type { Network } from "@/config/networks.js";
+import type { Common } from "@/Ponder.js";
 import type { Block } from "@/types/block.js";
 import type { Log } from "@/types/log.js";
 import type { Transaction } from "@/types/transaction.js";
+import { formatShortDate } from "@/utils/date.js";
 
 export type LogEvent = {
   logFilterName: string;
@@ -35,8 +38,11 @@ export type EventAggregatorEvents = {
 
 export type EventAggregatorMetrics = {};
 
-export interface EventAggregatorService
-  extends Emittery<EventAggregatorEvents> {
+export abstract class EventAggregatorService extends Emittery<EventAggregatorEvents> {
+  protected common;
+  protected logFilters: LogFilter[];
+  private networks: Network[];
+
   // Minimum timestamp at which events are available (across all networks).
   checkpoint: number;
   // Minimum finalized timestamp (across all networks).
@@ -45,9 +51,48 @@ export interface EventAggregatorService
   // Timestamp at which the historical sync was completed (across all networks).
   historicalSyncCompletedAt?: number;
 
+  // Per-network event timestamp checkpoints.
+  private networkCheckpoints: Record<
+    number,
+    {
+      isHistoricalSyncComplete: boolean;
+      historicalCheckpoint: number;
+      realtimeCheckpoint: number;
+      finalityCheckpoint: number;
+    }
+  >;
+
   metrics: EventAggregatorMetrics;
 
-  subscribeToSyncEvents?: () => void;
+  constructor({
+    common,
+    networks,
+    logFilters,
+  }: {
+    common: Common;
+    networks: Network[];
+    logFilters: LogFilter[];
+  }) {
+    super();
+
+    this.common = common;
+    this.logFilters = logFilters;
+    this.networks = networks;
+    this.metrics = {};
+
+    this.checkpoint = 0;
+    this.finalityCheckpoint = 0;
+
+    this.networkCheckpoints = {};
+    this.networks.forEach((network) => {
+      this.networkCheckpoints[network.chainId] = {
+        isHistoricalSyncComplete: false,
+        historicalCheckpoint: 0,
+        realtimeCheckpoint: 0,
+        finalityCheckpoint: 0,
+      };
+    });
+  }
 
   /** Fetches events for all registered log filters between the specified timestamps.
    *
@@ -56,7 +101,7 @@ export interface EventAggregatorService
    * @param options.includeLogFilterEvents Map of log filter name -> selector -> ABI event item for which to include full event objects.
    * @returns A promise resolving to an array of log events.
    */
-  getEvents({
+  abstract getEvents({
     fromTimestamp,
     toTimestamp,
     includeLogFilterEvents,
@@ -82,37 +127,186 @@ export interface EventAggregatorService
     };
   }>;
 
-  handleNewHistoricalCheckpoint({
+  subscribeToSyncEvents?(): void;
+
+  kill() {
+    this.clearListeners();
+  }
+
+  handleNewHistoricalCheckpoint = ({
     chainId,
     timestamp,
   }: {
     chainId: number;
     timestamp: number;
-  }): void;
+  }) => {
+    this.networkCheckpoints[chainId].historicalCheckpoint = timestamp;
 
-  handleHistoricalSyncComplete({ chainId }: { chainId: number }): void;
+    this.common.logger.trace({
+      service: "aggregator",
+      msg: `New historical checkpoint at ${timestamp} [${formatShortDate(
+        timestamp
+      )}] (chainId=${chainId})`,
+    });
 
-  handleNewRealtimeCheckpoint({
+    this.recalculateCheckpoint();
+  };
+
+  handleHistoricalSyncComplete = ({ chainId }: { chainId: number }) => {
+    this.networkCheckpoints[chainId].isHistoricalSyncComplete = true;
+    this.recalculateCheckpoint();
+
+    // If every network has completed the historical sync, set the metric.
+    const networkCheckpoints = Object.values(this.networkCheckpoints);
+    if (networkCheckpoints.every((n) => n.isHistoricalSyncComplete)) {
+      const maxHistoricalCheckpoint = Math.max(
+        ...networkCheckpoints.map((n) => n.historicalCheckpoint)
+      );
+      this.historicalSyncCompletedAt = maxHistoricalCheckpoint;
+
+      this.common.logger.debug({
+        service: "aggregator",
+        msg: `Completed historical sync across all networks`,
+      });
+    }
+  };
+
+  handleNewRealtimeCheckpoint = ({
     chainId,
     timestamp,
   }: {
     chainId: number;
     timestamp: number;
-  }): void;
+  }) => {
+    this.networkCheckpoints[chainId].realtimeCheckpoint = timestamp;
 
-  handleNewFinalityCheckpoint({
+    this.common.logger.trace({
+      service: "aggregator",
+      msg: `New realtime checkpoint at ${timestamp} [${formatShortDate(
+        timestamp
+      )}] (chainId=${chainId})`,
+    });
+
+    this.recalculateCheckpoint();
+  };
+
+  handleNewFinalityCheckpoint = ({
     chainId,
     timestamp,
   }: {
     chainId: number;
     timestamp: number;
-  }): void;
+  }) => {
+    this.networkCheckpoints[chainId].finalityCheckpoint = timestamp;
+    this.recalculateFinalityCheckpoint();
+  };
 
-  handleReorg({
+  handleReorg = ({
     commonAncestorTimestamp,
   }: {
     commonAncestorTimestamp: number;
-  }): void;
+  }) => {
+    this.emit("reorg", { commonAncestorTimestamp });
+  };
 
-  kill(): void;
+  protected decodeEvents = (
+    events: {
+      logFilterName: string;
+      log: Log;
+      block: Block;
+      transaction: Transaction;
+    }[],
+    includeLogFilterEvents: {
+      [logFilterName: LogFilterName]:
+        | {
+            bySelector: { [selector: Hex]: LogEventMetadata };
+          }
+        | undefined;
+    }
+  ) => {
+    return events.reduce<LogEvent[]>((acc, event) => {
+      const selector = event.log.topics[0];
+      if (!selector) {
+        throw new Error(`Received an event log with no selector: ${event.log}`);
+      }
+
+      const logEventMetadata =
+        includeLogFilterEvents[event.logFilterName]?.bySelector[selector];
+      if (!logEventMetadata) {
+        throw new Error(
+          `Metadata for event ${event.logFilterName}:${selector} not found in includeLogFilterEvents`
+        );
+      }
+      const { abiItem, safeName } = logEventMetadata;
+
+      try {
+        const decodedLog = decodeEventLog({
+          abi: [abiItem],
+          data: event.log.data,
+          topics: event.log.topics,
+        });
+
+        acc.push({
+          logFilterName: event.logFilterName,
+          eventName: safeName,
+          params: decodedLog.args || {},
+          log: event.log,
+          block: event.block,
+          transaction: event.transaction,
+        });
+      } catch (err) {
+        // TODO: emit a warning here that a log was not decoded.
+        this.common.logger.error({
+          service: "app",
+          msg: `Unable to decode log (skipping it): ${event.log}`,
+          error: err as Error,
+        });
+      }
+
+      return acc;
+    }, []);
+  };
+
+  private recalculateCheckpoint = () => {
+    const checkpoints = Object.values(this.networkCheckpoints).map((n) =>
+      n.isHistoricalSyncComplete
+        ? Math.max(n.historicalCheckpoint, n.realtimeCheckpoint)
+        : n.historicalCheckpoint
+    );
+    const newCheckpoint = Math.min(...checkpoints);
+
+    if (newCheckpoint > this.checkpoint) {
+      this.checkpoint = newCheckpoint;
+
+      this.common.logger.trace({
+        service: "aggregator",
+        msg: `New event checkpoint at ${this.checkpoint} [${formatShortDate(
+          this.checkpoint
+        )}]`,
+      });
+
+      this.emit("newCheckpoint", { timestamp: this.checkpoint });
+    }
+  };
+
+  private recalculateFinalityCheckpoint = () => {
+    const newFinalityCheckpoint = Math.min(
+      ...Object.values(this.networkCheckpoints).map((n) => n.finalityCheckpoint)
+    );
+
+    if (newFinalityCheckpoint > this.finalityCheckpoint) {
+      this.finalityCheckpoint = newFinalityCheckpoint;
+
+      this.common.logger.trace({
+        service: "aggregator",
+        msg: `New finality checkpoint at ${
+          this.finalityCheckpoint
+        } [${formatShortDate(this.finalityCheckpoint)}]`,
+      });
+
+      this.emit("newFinalityCheckpoint", {
+        timestamp: this.finalityCheckpoint,
+      });
+    }
+  };
 }

--- a/packages/core/src/event-aggregator/service.ts
+++ b/packages/core/src/event-aggregator/service.ts
@@ -47,6 +47,8 @@ export interface EventAggregatorService
 
   metrics: EventAggregatorMetrics;
 
+  subscribeToSyncEvents?: () => void;
+
   /** Fetches events for all registered log filters between the specified timestamps.
    *
    * @param options.fromTimestamp Timestamp to start including events (inclusive).
@@ -111,4 +113,6 @@ export interface EventAggregatorService
   }: {
     commonAncestorTimestamp: number;
   }): void;
+
+  kill(): void;
 }

--- a/packages/core/src/event-aggregator/service.ts
+++ b/packages/core/src/event-aggregator/service.ts
@@ -54,7 +54,6 @@ export interface EventAggregatorService
    * @param options.includeLogFilterEvents Map of log filter name -> selector -> ABI event item for which to include full event objects.
    * @returns A promise resolving to an array of log events.
    */
-  // TODO: Remove void from return type
   getEvents({
     fromTimestamp,
     toTimestamp,
@@ -79,7 +78,7 @@ export interface EventAggregatorService
         count: number;
       }[];
     };
-  }> | void;
+  }>;
 
   handleNewHistoricalCheckpoint({
     chainId,

--- a/packages/core/src/event-store/postgres/migrations.ts
+++ b/packages/core/src/event-store/postgres/migrations.ts
@@ -1,4 +1,5 @@
-import { type Migration, type MigrationProvider, Kysely, sql } from "kysely";
+import type { Kysely } from "kysely";
+import { type Migration, type MigrationProvider, sql } from "kysely";
 
 const migrations: Record<string, Migration> = {
   ["2023_05_15_0_initial"]: {

--- a/packages/core/src/event-store/postgres/store.ts
+++ b/packages/core/src/event-store/postgres/store.ts
@@ -7,7 +7,7 @@ import {
   PostgresDialect,
   sql,
 } from "kysely";
-import pg from "pg";
+import type pg from "pg";
 import type { Address, Hex, RpcBlock, RpcLog, RpcTransaction } from "viem";
 
 import type { Block } from "@/types/block.js";
@@ -19,7 +19,7 @@ import { intToBlob } from "@/utils/encode.js";
 import { mergeIntervals } from "@/utils/intervals.js";
 import { range } from "@/utils/range.js";
 
-import type { EventStore } from "../store.js";
+import type { Cursor, EventStore } from "../store.js";
 import {
   type EventStoreTables,
   type InsertableBlock,
@@ -412,12 +412,12 @@ export class PostgresEventStore implements EventStore {
       : null;
   };
 
-  // TODO: Pass and return cursor for pagination
   async *getLogEvents({
     fromTimestamp,
     toTimestamp,
     filters = [],
     pageSize = 10_000,
+    cursor,
   }: {
     fromTimestamp: number;
     toTimestamp: number;
@@ -431,6 +431,7 @@ export class PostgresEventStore implements EventStore {
       includeEventSelectors?: Hex[];
     }[];
     pageSize: number;
+    cursor?: Cursor;
   }) {
     const baseQuery = this.db
       .with(
@@ -619,15 +620,6 @@ export class PostgresEventStore implements EventStore {
       count: Number(c.count),
     }));
 
-    let cursor:
-      | {
-          timestamp: Buffer;
-          chainId: number;
-          blockNumber: Buffer;
-          logIndex: number;
-        }
-      | undefined = undefined;
-
     while (true) {
       let query = includedLogsBaseQuery.limit(pageSize);
       if (cursor) {
@@ -780,6 +772,7 @@ export class PostgresEventStore implements EventStore {
         metadata: {
           pageEndsAtTimestamp,
           counts: eventCounts,
+          cursor,
         },
       };
 

--- a/packages/core/src/event-store/postgres/store.ts
+++ b/packages/core/src/event-store/postgres/store.ts
@@ -412,6 +412,7 @@ export class PostgresEventStore implements EventStore {
       : null;
   };
 
+  // TODO: Pass and return cursor for pagination
   async *getLogEvents({
     fromTimestamp,
     toTimestamp,

--- a/packages/core/src/event-store/sqlite/migrations.ts
+++ b/packages/core/src/event-store/sqlite/migrations.ts
@@ -1,4 +1,5 @@
-import { type Migration, type MigrationProvider, Kysely } from "kysely";
+import type { Kysely } from "kysely";
+import { type Migration, type MigrationProvider } from "kysely";
 
 const migrations: Record<string, Migration> = {
   ["2023_05_15_0_initial"]: {

--- a/packages/core/src/event-store/sqlite/store.ts
+++ b/packages/core/src/event-store/sqlite/store.ts
@@ -18,7 +18,7 @@ import { intToBlob } from "@/utils/encode.js";
 import { mergeIntervals } from "@/utils/intervals.js";
 import { range } from "@/utils/range.js";
 
-import type { EventStore } from "../store.js";
+import type { Cursor, EventStore } from "../store.js";
 import {
   type EventStoreTables,
   type InsertableBlock,
@@ -388,6 +388,7 @@ export class SqliteEventStore implements EventStore {
     toTimestamp,
     filters = [],
     pageSize = 10_000,
+    cursor,
   }: {
     fromTimestamp: number;
     toTimestamp: number;
@@ -401,6 +402,7 @@ export class SqliteEventStore implements EventStore {
       includeEventSelectors?: Hex[];
     }[];
     pageSize: number;
+    cursor?: Cursor;
   }) {
     const baseQuery = this.db
       .with(
@@ -596,15 +598,6 @@ export class SqliteEventStore implements EventStore {
       count: Number(c.count),
     }));
 
-    let cursor:
-      | {
-          timestamp: Buffer;
-          chainId: number;
-          blockNumber: Buffer;
-          logIndex: number;
-        }
-      | undefined = undefined;
-
     while (true) {
       let query = includedLogsBaseQuery.limit(pageSize);
       if (cursor) {
@@ -757,6 +750,7 @@ export class SqliteEventStore implements EventStore {
         metadata: {
           pageEndsAtTimestamp,
           counts: eventCounts,
+          cursor,
         },
       };
 

--- a/packages/core/src/event-store/store.ts
+++ b/packages/core/src/event-store/store.ts
@@ -27,6 +27,13 @@ export type ContractReadResult = {
   result: Hex;
 };
 
+export type Cursor = {
+  timestamp: Buffer;
+  chainId: number;
+  blockNumber: Buffer;
+  logIndex: number;
+};
+
 export interface EventStore {
   kind: "sqlite" | "postgres";
   db: Kysely<any>;
@@ -106,6 +113,7 @@ export interface EventStore {
       includeEventSelectors?: Hex[];
     }[];
     pageSize?: number;
+    cursor?: Cursor;
   }): AsyncGenerator<{
     events: {
       logFilterName: string;
@@ -120,6 +128,7 @@ export interface EventStore {
         selector: Hex;
         count: number;
       }[];
+      cursor?: Cursor;
     };
   }>;
 }

--- a/packages/core/src/indexing-server/resolvers.ts
+++ b/packages/core/src/indexing-server/resolvers.ts
@@ -1,89 +1,65 @@
+import type { IFieldResolver, IResolvers } from "@graphql-tools/utils";
+import ApolloBigInt from "apollo-type-bigint";
+import { PubSub } from "graphql-subscriptions";
+
 import { EventStore } from "@/event-store/store";
 import { blobToBigInt } from "@/utils/decode";
 import { intToBlob } from "@/utils/encode";
 
+export const HISTORICAL_CHECKPOINT = "historicalCheckpoint";
+
 const PAGE_SIZE = 10_000;
 
-export const getResolvers = (eventStore: EventStore) => {
-  const getLogEvents = async (args: any) => {
-    try {
-      const { fromTimestamp, toTimestamp, filters, cursor } = args;
+export const getResolvers = (
+  eventStore: EventStore,
+  pubsub: PubSub
+): IResolvers<any, unknown> => {
+  const getLogEvents: IFieldResolver<any, unknown> = async (_, args) => {
+    const { fromTimestamp, toTimestamp, filters, cursor } = args;
 
-      const iterator = eventStore.getLogEvents({
-        fromTimestamp,
-        toTimestamp,
-        filters,
-        cursor: cursor && {
-          ...cursor,
-          timestamp: intToBlob(cursor.timestamp),
-          blockNumber: intToBlob(cursor.blockNumber),
-        },
-        pageSize: PAGE_SIZE,
-      });
+    const iterator = eventStore.getLogEvents({
+      fromTimestamp,
+      toTimestamp,
+      filters,
+      cursor: cursor && {
+        ...cursor,
+        timestamp: intToBlob(cursor.timestamp),
+        blockNumber: intToBlob(cursor.blockNumber),
+      },
+      pageSize: PAGE_SIZE,
+    });
 
-      for await (const page of iterator) {
-        const { events, metadata } = page;
+    for await (const page of iterator) {
+      const { events, metadata } = page;
 
-        return {
-          events: events.map((event) => ({
-            ...event,
-            log: {
-              ...event.log,
-              // TODO: Resolve bigint types in GQL
-              blockNumber: event.log.blockNumber.toString(),
-            },
-            block: {
-              ...event.block,
-              // TODO: Resolve bigint types in GQL
-              baseFeePerGas:
-                event.block.baseFeePerGas !== null &&
-                event.block.baseFeePerGas.toString(),
-              difficulty: event.block.difficulty.toString(),
-              gasLimit: event.block.gasLimit.toString(),
-              gasUsed: event.block.gasUsed.toString(),
-              number: event.block.number.toString(),
-              size: event.block.size.toString(),
-              timestamp: event.block.timestamp.toString(),
-              totalDifficulty: event.block.totalDifficulty.toString(),
-            },
-            transaction: {
-              ...event.transaction,
-              // TODO: Resolve bigint types in GQL
-              blockNumber: event.transaction.blockNumber.toString(),
-              gas: event.transaction.gas.toString(),
-              v: event.transaction.v.toString(),
-              value: event.transaction.value.toString(),
-              gasPrice:
-                event.transaction.gasPrice !== undefined &&
-                event.transaction.gasPrice.toString(),
-              maxFeePerGas:
-                event.transaction.maxFeePerGas !== undefined &&
-                event.transaction.maxFeePerGas.toString(),
-              maxPriorityFeePerGas:
-                event.transaction.maxPriorityFeePerGas !== undefined &&
-                event.transaction.maxPriorityFeePerGas.toString(),
-            },
-          })),
-          metadata: {
-            ...metadata,
-            cursor: metadata.cursor && {
-              ...metadata.cursor,
-              timestamp: Number(blobToBigInt(metadata.cursor.timestamp)),
-              blockNumber: Number(blobToBigInt(metadata.cursor.blockNumber)),
-            },
-            isLastPage: events.length < PAGE_SIZE,
+      return {
+        events,
+        metadata: {
+          ...metadata,
+          cursor: metadata.cursor && {
+            ...metadata.cursor,
+            timestamp: Number(blobToBigInt(metadata.cursor.timestamp)),
+            blockNumber: Number(blobToBigInt(metadata.cursor.blockNumber)),
           },
-        };
-      }
-
-      throw new Error("getLogEvents iterator should run atleast once");
-    } catch (err) {
-      console.error(err);
-      throw new Error("Debug error in GQL server");
+          isLastPage: events.length < PAGE_SIZE,
+        },
+      };
     }
+
+    throw new Error("getLogEvents iterator should run atleast once");
   };
 
   return {
-    getLogEvents,
+    BigInt: new ApolloBigInt("bigInt"),
+
+    Query: {
+      getLogEvents,
+    },
+
+    Subscription: {
+      onNewHistoricalCheckpoint: {
+        subscribe: () => pubsub.asyncIterator(HISTORICAL_CHECKPOINT),
+      },
+    },
   };
 };

--- a/packages/core/src/indexing-server/resolvers.ts
+++ b/packages/core/src/indexing-server/resolvers.ts
@@ -1,22 +1,84 @@
-import { GraphQLFieldResolver } from "graphql";
+import { EventStore } from "@/event-store/store";
+import { blobToBigInt } from "@/utils/decode";
 
-export const getResolvers = () => {
-  const getLogEvents: GraphQLFieldResolver<{ request: unknown }, {}> = () =>
-    // _,
-    // args,
-    // context
-    {
-      // TODO: Fetch from eventStore and send in response
+const PAGE_SIZE = 10_000;
 
-      return {
-        events: [],
-        metadata: {
-          pageEndsAtTimestamp: 0,
-          counts: [],
-          isLastPage: true,
-        },
-      };
-    };
+export const getResolvers = (eventStore: EventStore) => {
+  const getLogEvents = async (args: any) => {
+    try {
+      const { fromTimestamp, toTimestamp, filters, cursor } = args;
+
+      // TODO: Sanitize filters and cursor
+
+      const iterator = eventStore.getLogEvents({
+        fromTimestamp,
+        toTimestamp,
+        filters,
+        cursor,
+        pageSize: PAGE_SIZE,
+      });
+
+      for await (const page of iterator) {
+        const { events, metadata } = page;
+
+        return {
+          events: events.map((event) => ({
+            ...event,
+            log: {
+              ...event.log,
+              // TODO: Resolve bigint types in GQL
+              blockNumber: event.log.blockNumber.toString(),
+            },
+            block: {
+              ...event.block,
+              // TODO: Resolve bigint types in GQL
+              baseFeePerGas:
+                event.block.baseFeePerGas !== null &&
+                event.block.baseFeePerGas.toString(),
+              difficulty: event.block.difficulty.toString(),
+              gasLimit: event.block.gasLimit.toString(),
+              gasUsed: event.block.gasUsed.toString(),
+              number: event.block.number.toString(),
+              size: event.block.size.toString(),
+              timestamp: event.block.timestamp.toString(),
+              totalDifficulty: event.block.totalDifficulty.toString(),
+            },
+            transaction: {
+              ...event.transaction,
+              // TODO: Resolve bigint types in GQL
+              blockNumber: event.transaction.blockNumber.toString(),
+              gas: event.transaction.gas.toString(),
+              v: event.transaction.v.toString(),
+              value: event.transaction.value.toString(),
+              gasPrice:
+                event.transaction.gasPrice &&
+                event.transaction.gasPrice.toString(),
+              maxFeePerGas:
+                event.transaction.maxFeePerGas &&
+                event.transaction.maxFeePerGas.toString(),
+              maxPriorityFeePerGas:
+                event.transaction.maxPriorityFeePerGas &&
+                event.transaction.maxPriorityFeePerGas.toString(),
+            },
+          })),
+          metadata: {
+            ...metadata,
+            cursor: metadata.cursor && {
+              ...metadata.cursor,
+              timestamp: Number(blobToBigInt(metadata.cursor.timestamp)),
+              blockNumber: Number(blobToBigInt(metadata.cursor.blockNumber)),
+            },
+            isLastPage: events.length < PAGE_SIZE,
+          },
+        };
+      }
+
+      throw new Error("getLogEvents iterator should run atleast once");
+    } catch (err) {
+      console.error(err);
+      throw new Error("Debug error in GQL server");
+    }
+  };
 
   return {
     getLogEvents,

--- a/packages/core/src/indexing-server/resolvers.ts
+++ b/packages/core/src/indexing-server/resolvers.ts
@@ -2,7 +2,7 @@ import { EventStore } from "@/event-store/store";
 import { blobToBigInt } from "@/utils/decode";
 import { intToBlob } from "@/utils/encode";
 
-const PAGE_SIZE = 100;
+const PAGE_SIZE = 10_000;
 
 export const getResolvers = (eventStore: EventStore) => {
   const getLogEvents = async (args: any) => {

--- a/packages/core/src/indexing-server/resolvers.ts
+++ b/packages/core/src/indexing-server/resolvers.ts
@@ -1,0 +1,24 @@
+import { GraphQLFieldResolver } from "graphql";
+
+export const getResolvers = () => {
+  const getLogEvents: GraphQLFieldResolver<{ request: unknown }, {}> = () =>
+    // _,
+    // args,
+    // context
+    {
+      // TODO: Fetch from eventStore and send in response
+
+      return {
+        events: [],
+        metadata: {
+          pageEndsAtTimestamp: 0,
+          counts: [],
+          isLastPage: true,
+        },
+      };
+    };
+
+  return {
+    getLogEvents,
+  };
+};

--- a/packages/core/src/indexing-server/resolvers.ts
+++ b/packages/core/src/indexing-server/resolvers.ts
@@ -1,16 +1,19 @@
 import type { IFieldResolver, IResolvers } from "@graphql-tools/utils";
-import ApolloBigInt from "apollo-type-bigint";
 import type { PubSub } from "graphql-subscriptions";
+import { createRequire } from "node:module";
 
-import type { EventStore } from "@/event-store/store";
-import { blobToBigInt } from "@/utils/decode";
-import { intToBlob } from "@/utils/encode";
+import type { EventStore } from "@/event-store/store.js";
+import { blobToBigInt } from "@/utils/decode.js";
+import { intToBlob } from "@/utils/encode.js";
 
 export const HISTORICAL_CHECKPOINT = "historicalCheckpoint";
 export const SYNC_COMPLETE = "syncComplete";
 export const REALTIME_CHECKPOINT = "realtimeCheckpoint";
 export const FINALITY_CHECKPOINT = "finalityCheckpoint";
 export const SHALLOW_REORG = "shallowReorg";
+
+const require = createRequire(import.meta.url);
+const { default: ApolloBigInt } = require("apollo-type-bigint");
 
 const PAGE_SIZE = 10_000;
 

--- a/packages/core/src/indexing-server/resolvers.ts
+++ b/packages/core/src/indexing-server/resolvers.ts
@@ -7,6 +7,10 @@ import { blobToBigInt } from "@/utils/decode";
 import { intToBlob } from "@/utils/encode";
 
 export const HISTORICAL_CHECKPOINT = "historicalCheckpoint";
+export const SYNC_COMPLETE = "syncComplete";
+export const REALTIME_CHECKPOINT = "realtimeCheckpoint";
+export const FINALITY_CHECKPOINT = "finalityCheckpoint";
+export const SHALLOW_REORG = "shallowReorg";
 
 const PAGE_SIZE = 10_000;
 
@@ -59,6 +63,18 @@ export const getResolvers = (
     Subscription: {
       onNewHistoricalCheckpoint: {
         subscribe: () => pubsub.asyncIterator(HISTORICAL_CHECKPOINT),
+      },
+      onHistoricalSyncComplete: {
+        subscribe: () => pubsub.asyncIterator(SYNC_COMPLETE),
+      },
+      onNewRealtimeCheckpoint: {
+        subscribe: () => pubsub.asyncIterator(REALTIME_CHECKPOINT),
+      },
+      onNewFinalityCheckpoint: {
+        subscribe: () => pubsub.asyncIterator(FINALITY_CHECKPOINT),
+      },
+      onReorg: {
+        subscribe: () => pubsub.asyncIterator(SHALLOW_REORG),
       },
     },
   };

--- a/packages/core/src/indexing-server/resolvers.ts
+++ b/packages/core/src/indexing-server/resolvers.ts
@@ -1,8 +1,8 @@
 import type { IFieldResolver, IResolvers } from "@graphql-tools/utils";
 import ApolloBigInt from "apollo-type-bigint";
-import { PubSub } from "graphql-subscriptions";
+import type { PubSub } from "graphql-subscriptions";
 
-import { EventStore } from "@/event-store/store";
+import type { EventStore } from "@/event-store/store";
 import { blobToBigInt } from "@/utils/decode";
 import { intToBlob } from "@/utils/encode";
 

--- a/packages/core/src/indexing-server/resolvers.ts
+++ b/packages/core/src/indexing-server/resolvers.ts
@@ -51,13 +51,13 @@ export const getResolvers = (eventStore: EventStore) => {
               v: event.transaction.v.toString(),
               value: event.transaction.value.toString(),
               gasPrice:
-                event.transaction.gasPrice &&
+                event.transaction.gasPrice !== undefined &&
                 event.transaction.gasPrice.toString(),
               maxFeePerGas:
-                event.transaction.maxFeePerGas &&
+                event.transaction.maxFeePerGas !== undefined &&
                 event.transaction.maxFeePerGas.toString(),
               maxPriorityFeePerGas:
-                event.transaction.maxPriorityFeePerGas &&
+                event.transaction.maxPriorityFeePerGas !== undefined &&
                 event.transaction.maxPriorityFeePerGas.toString(),
             },
           })),

--- a/packages/core/src/indexing-server/resolvers.ts
+++ b/packages/core/src/indexing-server/resolvers.ts
@@ -1,20 +1,23 @@
 import { EventStore } from "@/event-store/store";
 import { blobToBigInt } from "@/utils/decode";
+import { intToBlob } from "@/utils/encode";
 
-const PAGE_SIZE = 10_000;
+const PAGE_SIZE = 100;
 
 export const getResolvers = (eventStore: EventStore) => {
   const getLogEvents = async (args: any) => {
     try {
       const { fromTimestamp, toTimestamp, filters, cursor } = args;
 
-      // TODO: Sanitize filters and cursor
-
       const iterator = eventStore.getLogEvents({
         fromTimestamp,
         toTimestamp,
         filters,
-        cursor,
+        cursor: cursor && {
+          ...cursor,
+          timestamp: intToBlob(cursor.timestamp),
+          blockNumber: intToBlob(cursor.blockNumber),
+        },
         pageSize: PAGE_SIZE,
       });
 

--- a/packages/core/src/indexing-server/schema.ts
+++ b/packages/core/src/indexing-server/schema.ts
@@ -128,7 +128,19 @@ export const indexingSchema = `
     timestamp: Int!
   }
 
+  type SyncComplete {
+    chainId: Int!
+  }
+
+  type Reorg {
+    commonAncestorTimestamp: Int!
+  }
+
   type Subscription {
     onNewHistoricalCheckpoint: Checkpoint!
+    onHistoricalSyncComplete: SyncComplete!
+    onNewRealtimeCheckpoint: Checkpoint!
+    onNewFinalityCheckpoint: Checkpoint!
+    onReorg: Reorg!
   }
 `;

--- a/packages/core/src/indexing-server/schema.ts
+++ b/packages/core/src/indexing-server/schema.ts
@@ -1,0 +1,50 @@
+import { buildSchema } from "graphql";
+
+export const indexingSchema = buildSchema(`
+  input Filter {
+    name: String!
+    chainId: Int!
+    address: [String!]
+    topics: [String]
+    fromBlock: Int
+    toBlock: Int
+    includeEventSelectors: [String]
+  }
+
+  # TODO: Add actual types
+  type Event {
+    logFilterName: String!
+    # log: Log!
+    # block: Block!
+    # transaction: Transaction! 
+  }
+
+  type Count {
+    logFilterName: String!
+    selector: String!
+    count: Int!
+  }
+
+  type Cursor {
+    timestamp: Int!
+    chainId: Int!
+    blockNumber: Int!
+    logIndex: Int!
+  }
+
+  type Metadata {
+    pageEndsAtTimestamp: Int
+    counts: [Count!]!
+    cursor: Cursor
+    isLastPage: Boolean!
+  }
+
+  type LogEventsResult {
+    events: [Event!] 
+    metadata: Metadata
+  }
+
+  type Query {
+    getLogEvents(fromTimestamp: Int!, toTimestamp: Int!, filters: [Filter!]): LogEventsResult!
+  }
+`);

--- a/packages/core/src/indexing-server/schema.ts
+++ b/packages/core/src/indexing-server/schema.ts
@@ -114,6 +114,11 @@ export const indexingSchema = `
     metadata: Metadata
   }
 
+  type NetworkHistoricalSync {
+    checkpoint: Int!
+    isSyncComplete: Int!
+  }
+
   type Query {
     getLogEvents(
       fromTimestamp: Int!,
@@ -121,6 +126,9 @@ export const indexingSchema = `
       filters: [Filter!],
       cursor: CursorInput
     ): LogEventsResult!
+    getNetworkHistoricalSync(
+      chainId: Int!
+    ): NetworkHistoricalSync!
   }
 
   type Checkpoint {

--- a/packages/core/src/indexing-server/schema.ts
+++ b/packages/core/src/indexing-server/schema.ts
@@ -1,22 +1,94 @@
 import { buildSchema } from "graphql";
 
 export const indexingSchema = buildSchema(`
+  scalar BigInt
+
   input Filter {
     name: String!
     chainId: Int!
     address: [String!]
-    topics: [String]
+    topics: [[String!]]
     fromBlock: Int
     toBlock: Int
     includeEventSelectors: [String]
   }
 
-  # TODO: Add actual types
+  input CursorInput {
+    timestamp: Int!
+    chainId: Int!
+    blockNumber: Int!
+    logIndex: Int!
+  }
+
+  # src/types/log.ts
+  type Log {
+    id: String!
+    address: String!
+    blockHash: String!
+    blockNumber: BigInt!
+    data: String!
+    logIndex: Int!
+    removed: Boolean!
+    topics: [String!]
+    transactionHash: String!
+    transactionIndex: Int!
+  }
+
+  # src/types/log.ts
+  type Block {
+    baseFeePerGas: BigInt
+    difficulty: BigInt!
+    extraData: String!
+    gasLimit: BigInt!
+    gasUsed: BigInt!
+    hash: String!
+    logsBloom: String!
+    miner: String!
+    mixHash: String!
+    nonce: String!
+    number: BigInt!
+    parentHash: String!
+    receiptsRoot: String!
+    sha3Uncles: String!
+    size: BigInt!
+    stateRoot: String!
+    timestamp: BigInt!
+    totalDifficulty: BigInt!
+    transactionsRoot: String!
+  }
+
+  type AccessListItem {
+    address: String!
+    storageKeys: [String!]
+  }
+
+  # src/types/transaction.ts
+  type Transaction {
+    blockHash: String!
+    blockNumber: BigInt!
+    from: String!
+    gas: BigInt!
+    hash: String!
+    input: String!
+    nonce: Int!
+    r: String!
+    s: String!
+    to: String
+    transactionIndex: Int!
+    v: BigInt!
+    value: BigInt!
+    type: String!
+    gasPrice: BigInt
+    accessList: [AccessListItem]
+    maxFeePerGas: BigInt
+    maxPriorityFeePerGas: BigInt
+  }
+
   type Event {
     logFilterName: String!
-    # log: Log!
-    # block: Block!
-    # transaction: Transaction! 
+    log: Log!
+    block: Block!
+    transaction: Transaction!
   }
 
   type Count {
@@ -45,6 +117,11 @@ export const indexingSchema = buildSchema(`
   }
 
   type Query {
-    getLogEvents(fromTimestamp: Int!, toTimestamp: Int!, filters: [Filter!]): LogEventsResult!
+    getLogEvents(
+      fromTimestamp: Int!,
+      toTimestamp: Int!,
+      filters: [Filter!],
+      cursor: CursorInput
+    ): LogEventsResult!
   }
 `);

--- a/packages/core/src/indexing-server/schema.ts
+++ b/packages/core/src/indexing-server/schema.ts
@@ -1,6 +1,4 @@
-import { buildSchema } from "graphql";
-
-export const indexingSchema = buildSchema(`
+export const indexingSchema = `
   scalar BigInt
 
   input Filter {
@@ -124,4 +122,13 @@ export const indexingSchema = buildSchema(`
       cursor: CursorInput
     ): LogEventsResult!
   }
-`);
+
+  type Checkpoint {
+    chainId: Int!
+    timestamp: Int!
+  }
+
+  type Subscription {
+    onNewHistoricalCheckpoint: Checkpoint!
+  }
+`;

--- a/packages/core/src/indexing-server/service.ts
+++ b/packages/core/src/indexing-server/service.ts
@@ -98,9 +98,7 @@ export class IndexingServerService {
 
     const graphqlMiddleware = graphqlHTTP({
       schema: indexingSchema,
-      // TODO: Pass eventStore
-      rootValue: getResolvers(),
-      context: { store: this.eventStore },
+      rootValue: getResolvers(this.eventStore),
       graphiql: true,
     });
 

--- a/packages/core/src/indexing-server/service.ts
+++ b/packages/core/src/indexing-server/service.ts
@@ -5,12 +5,12 @@ import { PubSub } from "graphql-subscriptions";
 import { useServer } from "graphql-ws/lib/use/ws";
 import { WebSocketServer } from "ws";
 
-import type { Network } from "@/config/networks";
-import type { EventStore } from "@/event-store/store";
-import type { Common } from "@/Ponder";
-import { Server } from "@/utils/server";
+import type { Network } from "@/config/networks.js";
+import type { EventStore } from "@/event-store/store.js";
+import type { Common } from "@/Ponder.js";
+import { Server } from "@/utils/server.js";
 
-import type { NetworkCheckpoints } from "./resolvers";
+import type { NetworkCheckpoints } from "./resolvers.js";
 import {
   FINALITY_CHECKPOINT,
   getResolvers,
@@ -18,8 +18,8 @@ import {
   REALTIME_CHECKPOINT,
   SHALLOW_REORG,
   SYNC_COMPLETE,
-} from "./resolvers";
-import { indexingSchema } from "./schema";
+} from "./resolvers.js";
+import { indexingSchema } from "./schema.js";
 
 export class IndexingServerService {
   private common: Common;

--- a/packages/core/src/indexing-server/service.ts
+++ b/packages/core/src/indexing-server/service.ts
@@ -1,20 +1,20 @@
 import { makeExecutableSchema } from "@graphql-tools/schema";
-import express from "express";
-import { graphqlHTTP } from "express-graphql";
+import type express from "express";
+import { createHandler } from "graphql-http/lib/use/express";
 import { PubSub } from "graphql-subscriptions";
 import { useServer } from "graphql-ws/lib/use/ws";
-import { Server as WebSocketServer } from "ws";
+import { WebSocketServer } from "ws";
 
-import { Network } from "@/config/networks";
-import { EventStore } from "@/event-store/store";
+import type { Network } from "@/config/networks";
+import type { EventStore } from "@/event-store/store";
 import type { Common } from "@/Ponder";
 import { Server } from "@/utils/server";
 
+import type { NetworkCheckpoints } from "./resolvers";
 import {
   FINALITY_CHECKPOINT,
   getResolvers,
   HISTORICAL_CHECKPOINT,
-  NetworkCheckpoints,
   REALTIME_CHECKPOINT,
   SHALLOW_REORG,
   SYNC_COMPLETE,
@@ -84,9 +84,8 @@ export class IndexingServerService {
       }),
     });
 
-    const graphqlMiddleware = graphqlHTTP({
+    const graphqlMiddleware = createHandler({
       schema,
-      graphiql: true,
     });
 
     this.server.app?.use("/graphql", graphqlMiddleware);

--- a/packages/core/src/indexing-server/service.ts
+++ b/packages/core/src/indexing-server/service.ts
@@ -11,7 +11,14 @@ import { Server as WebSocketServer } from "ws";
 import { EventStore } from "@/event-store/store";
 import type { Common } from "@/Ponder";
 
-import { getResolvers, HISTORICAL_CHECKPOINT } from "./resolvers";
+import {
+  FINALITY_CHECKPOINT,
+  getResolvers,
+  HISTORICAL_CHECKPOINT,
+  REALTIME_CHECKPOINT,
+  SHALLOW_REORG,
+  SYNC_COMPLETE,
+} from "./resolvers";
 import { indexingSchema } from "./schema";
 
 // TODO: Refactor common GQL server code with ServerService
@@ -145,6 +152,30 @@ export class IndexingServerService {
   handleNewHistoricalCheckpoint(data: { chainId: number; timestamp: number }) {
     this.pubsub.publish(HISTORICAL_CHECKPOINT, {
       onNewHistoricalCheckpoint: data,
+    });
+  }
+
+  handleHistoricalSyncComplete(data: { chainId: number }) {
+    this.pubsub.publish(SYNC_COMPLETE, {
+      onHistoricalSyncComplete: data,
+    });
+  }
+
+  handleNewRealtimeCheckpoint(data: { chainId: number; timestamp: number }) {
+    this.pubsub.publish(REALTIME_CHECKPOINT, {
+      onNewRealtimeCheckpoint: data,
+    });
+  }
+
+  handleNewFinalityCheckpoint(data: { chainId: number; timestamp: number }) {
+    this.pubsub.publish(FINALITY_CHECKPOINT, {
+      onNewFinalityCheckpoint: data,
+    });
+  }
+
+  handleReorg(data: { commonAncestorTimestamp: number }) {
+    this.pubsub.publish(SHALLOW_REORG, {
+      onReorg: data,
     });
   }
 }

--- a/packages/core/src/indexing-server/service.ts
+++ b/packages/core/src/indexing-server/service.ts
@@ -1,0 +1,126 @@
+import cors from "cors";
+import express from "express";
+import { graphqlHTTP } from "express-graphql";
+import { createHttpTerminator } from "http-terminator";
+import { createServer, Server } from "node:http";
+
+import { EventStore } from "@/event-store/store";
+import type { Common } from "@/Ponder";
+
+import { getResolvers } from "./resolvers";
+import { indexingSchema } from "./schema";
+
+// TODO: Refactor common GQL server code with ServerService
+export class IndexingServerService {
+  private common: Common;
+  private eventStore: EventStore;
+
+  port: number;
+  app?: express.Express;
+
+  private terminate?: () => Promise<void>;
+
+  isSyncComplete = false;
+
+  constructor({
+    common,
+    eventStore,
+  }: {
+    common: Common;
+    eventStore: EventStore;
+  }) {
+    this.common = common;
+    this.eventStore = eventStore;
+    this.port = this.common.options.indexingPort;
+  }
+
+  async start() {
+    this.app = express();
+    this.app.use(cors());
+
+    // TODO: Register metrics for IndexingServerService similar to ServerService
+
+    const server = await new Promise<Server>((resolve, reject) => {
+      const server = createServer(this.app)
+        .on("error", (error) => {
+          if ((error as any).code === "EADDRINUSE") {
+            this.common.logger.warn({
+              service: "indexing-server",
+              msg: `Port ${this.port} was in use, trying port ${this.port + 1}`,
+            });
+            this.port += 1;
+            setTimeout(() => {
+              server.close();
+              server.listen(this.port);
+            }, 5);
+          } else {
+            reject(error);
+          }
+        })
+        .on("listening", () => {
+          // TODO: Set metrics for indexing server port
+          resolve(server);
+        })
+        .listen(this.port);
+    });
+
+    const terminator = createHttpTerminator({ server });
+    this.terminate = () => terminator.terminate();
+
+    this.common.logger.info({
+      service: "indexing-server",
+      msg: `Started listening on port ${this.port}`,
+    });
+
+    // TODO: Add server request handlers for metrics
+
+    // Server will respond as unhealthy until historical events have
+    // been processed OR 4.5 minutes have passed since the app was created.
+    // Similar to implementation in ServerService
+    this.app.get("/health", (_, res) => {
+      if (this.isSyncComplete) {
+        return res.status(200).send();
+      }
+
+      const max = this.common.options.maxHealthcheckDuration;
+      const elapsed = Math.floor(process.uptime());
+
+      if (elapsed > max) {
+        this.common.logger.warn({
+          service: "indexing-server",
+          msg: `Historical sync duration has exceeded the max healthcheck duration of ${max} seconds (current: ${elapsed}). Sevice is now responding as healthy and may serve incomplete data.`,
+        });
+        return res.status(200).send();
+      }
+
+      return res.status(503).send();
+    });
+
+    const graphqlMiddleware = graphqlHTTP({
+      schema: indexingSchema,
+      // TODO: Pass eventStore
+      rootValue: getResolvers(),
+      context: { store: this.eventStore },
+      graphiql: true,
+    });
+
+    this.app.use("/", graphqlMiddleware);
+  }
+
+  async kill() {
+    await this.terminate?.();
+    this.common.logger.debug({
+      service: "indexing-server",
+      msg: `Stopped listening on port ${this.port}`,
+    });
+  }
+
+  setIsSyncComplete() {
+    this.isSyncComplete = true;
+
+    this.common.logger.info({
+      service: "indexing-server",
+      msg: `Started responding as healthy`,
+    });
+  }
+}

--- a/packages/core/src/payment/service.ts
+++ b/packages/core/src/payment/service.ts
@@ -1,9 +1,12 @@
-import { ChannelStatus, Destination, utils } from "@cerc-io/nitro-node";
+import type { utils as utilsInterface } from "@cerc-io/nitro-node";
+import nitroNodePkg from "@cerc-io/nitro-node";
 import { hex2Bytes } from "@cerc-io/nitro-util";
 import assert from "node:assert";
 
 import type { ResolvedConfig } from "@/config/config";
 import type { Common } from "@/Ponder";
+
+const { ChannelStatus, Destination, utils } = nitroNodePkg;
 
 interface NetworkPayments
   extends NonNullable<ResolvedConfig["networks"][0]["payments"]> {
@@ -15,7 +18,7 @@ export class PaymentService {
   private config: NonNullable<ResolvedConfig["nitro"]>;
   private common: Common;
 
-  private nitro?: utils.Nitro;
+  private nitro?: utilsInterface.Nitro;
 
   private networkPaymentsMap: {
     [key: string]: NetworkPayments;

--- a/packages/core/src/payment/service.ts
+++ b/packages/core/src/payment/service.ts
@@ -2,8 +2,8 @@ import { ChannelStatus, Destination, utils } from "@cerc-io/nitro-node";
 import { hex2Bytes } from "@cerc-io/nitro-util";
 import assert from "node:assert";
 
-import { ResolvedConfig } from "@/config/config";
-import { Common } from "@/Ponder";
+import type { ResolvedConfig } from "@/config/config";
+import type { Common } from "@/Ponder";
 
 interface NetworkPayments
   extends NonNullable<ResolvedConfig["networks"][0]["payments"]> {

--- a/packages/core/src/schema/schema.ts
+++ b/packages/core/src/schema/schema.ts
@@ -1,15 +1,17 @@
+import type {
+  GraphQLEnumType,
+  GraphQLInputObjectType,
+  GraphQLObjectType,
+  GraphQLSchema,
+} from "graphql";
 import {
   type FieldDefinitionNode,
   type StringValueNode,
   GraphQLBoolean,
-  GraphQLEnumType,
   GraphQLFloat,
   GraphQLID,
-  GraphQLInputObjectType,
   GraphQLInt,
-  GraphQLObjectType,
   GraphQLScalarType,
-  GraphQLSchema,
   GraphQLString,
   Kind,
 } from "graphql";

--- a/packages/core/src/server/graphql/plural.ts
+++ b/packages/core/src/server/graphql/plural.ts
@@ -1,3 +1,4 @@
+import type { GraphQLObjectType } from "graphql";
 import {
   type GraphQLFieldConfig,
   type GraphQLFieldResolver,
@@ -6,7 +7,6 @@ import {
   GraphQLInt,
   GraphQLList,
   GraphQLNonNull,
-  GraphQLObjectType,
   GraphQLString,
 } from "graphql";
 

--- a/packages/core/src/server/graphql/singular.ts
+++ b/packages/core/src/server/graphql/singular.ts
@@ -1,9 +1,9 @@
+import type { GraphQLObjectType } from "graphql";
 import {
   type GraphQLFieldConfig,
   type GraphQLFieldResolver,
   GraphQLInt,
   GraphQLNonNull,
-  GraphQLObjectType,
 } from "graphql";
 
 import type { Entity } from "@/schema/types.js";

--- a/packages/core/src/server/service.ts
+++ b/packages/core/src/server/service.ts
@@ -145,7 +145,7 @@ export class ServerService {
     await this.server.kill();
   }
 
-  setIsHistoricalEventProcessingComplete() {
+  setIsHistoricalIndexingComplete() {
     this.isHistoricalIndexingComplete = true;
     this.server.isHealthy = true;
 

--- a/packages/core/src/server/service.ts
+++ b/packages/core/src/server/service.ts
@@ -1,37 +1,39 @@
-import cors from "cors";
-import express from "express";
 import type { FormattedExecutionResult, GraphQLSchema } from "graphql";
 import { formatError, GraphQLError } from "graphql";
 import { createHandler } from "graphql-http/lib/use/express";
-import { createHttpTerminator } from "http-terminator";
-import { createServer, Server } from "node:http";
 
 import type { Common } from "@/Ponder.js";
 import { graphiQLHtml } from "@/ui/graphiql.html.js";
 import type { UserStore } from "@/user-store/store.js";
+import { Server } from "@/utils/server.js";
 import { startClock } from "@/utils/timer.js";
 
 export class ServerService {
   private common: Common;
   private userStore: UserStore;
-
-  private port: number;
-  app?: express.Express;
-
-  private terminate?: () => Promise<void>;
+  private server: Server;
 
   isHistoricalIndexingComplete = false;
 
   constructor({ common, userStore }: { common: Common; userStore: UserStore }) {
     this.common = common;
     this.userStore = userStore;
-    this.port = this.common.options.port;
+
+    this.server = new Server({
+      common,
+      port: common.options.port,
+    });
+  }
+
+  get app() {
+    return this.server.app;
   }
 
   async start() {
-    this.app = express();
-    this.app.use(cors({ methods: ["GET", "POST", "OPTIONS", "HEAD"] }));
-    this.app.use((req, res, next) => {
+    await this.server.start();
+    this.common.metrics.ponder_server_port.set(this.server.port);
+
+    this.server.app?.use((req, res, next) => {
       const endClock = startClock();
       res.on("finish", () => {
         const responseDuration = endClock();
@@ -64,79 +66,6 @@ export class ServerService {
         );
       });
       next();
-    });
-
-    const server = await new Promise<Server>((resolve, reject) => {
-      const server = createServer(this.app)
-        .on("error", (error) => {
-          if ((error as any).code === "EADDRINUSE") {
-            this.common.logger.warn({
-              service: "server",
-              msg: `Port ${this.port} was in use, trying port ${this.port + 1}`,
-            });
-            this.port += 1;
-            setTimeout(() => {
-              server.close();
-              server.listen(this.port);
-            }, 5);
-          } else {
-            reject(error);
-          }
-        })
-        .on("listening", () => {
-          this.common.metrics.ponder_server_port.set(this.port);
-          resolve(server);
-        })
-        .listen(this.port);
-    });
-
-    const terminator = createHttpTerminator({ server });
-    this.terminate = () => terminator.terminate();
-
-    this.common.logger.info({
-      service: "server",
-      msg: `Started listening on port ${this.port}`,
-    });
-
-    this.app.post("/metrics", async (_, res) => {
-      try {
-        res.set("Content-Type", "text/plain; version=0.0.4; charset=utf-8");
-        res.end(await this.common.metrics.getMetrics());
-      } catch (error) {
-        res.status(500).end(error);
-      }
-    });
-
-    this.app.get("/metrics", async (_, res) => {
-      try {
-        res.set("Content-Type", "text/plain; version=0.0.4; charset=utf-8");
-        res.end(await this.common.metrics.getMetrics());
-      } catch (error) {
-        res.status(500).end(error);
-      }
-    });
-
-    // By default, the server will respond as unhealthy until historical index has
-    // been processed OR 4.5 minutes have passed since the app was created. This
-    // enables zero-downtime deployments on PaaS platforms like Railway and Render.
-    // Also see https://github.com/0xOlias/ponder/issues/24
-    this.app.get("/health", (_, res) => {
-      if (this.isHistoricalIndexingComplete) {
-        return res.status(200).send();
-      }
-
-      const max = this.common.options.maxHealthcheckDuration;
-      const elapsed = Math.floor(process.uptime());
-
-      if (elapsed > max) {
-        this.common.logger.warn({
-          service: "server",
-          msg: `Historical sync duration has exceeded the max healthcheck duration of ${max} seconds (current: ${elapsed}). Sevice is now responding as healthy and may serve incomplete data.`,
-        });
-        return res.status(200).send();
-      }
-
-      return res.status(503).send();
     });
   }
 
@@ -213,15 +142,12 @@ export class ServerService {
   }
 
   async kill() {
-    await this.terminate?.();
-    this.common.logger.debug({
-      service: "server",
-      msg: `Stopped listening on port ${this.port}`,
-    });
+    await this.server.kill();
   }
 
-  setIsHistoricalIndexingComplete() {
+  setIsHistoricalEventProcessingComplete() {
     this.isHistoricalIndexingComplete = true;
+    this.server.isHealthy = true;
 
     this.common.logger.info({
       service: "server",

--- a/packages/core/src/user-handlers/service.test.ts
+++ b/packages/core/src/user-handlers/service.test.ts
@@ -8,7 +8,7 @@ import type { HandlerFunctions } from "@/build/handlers.js";
 import { schemaHeader } from "@/build/schema.js";
 import { encodeLogFilterKey } from "@/config/logFilterKey.js";
 import type { LogEventMetadata } from "@/config/logFilters.js";
-import { EventAggregatorService } from "@/event-aggregator/service.js";
+import type { EventAggregatorService } from "@/event-aggregator/service.js";
 import { buildSchema } from "@/schema/schema.js";
 
 import { EventHandlerService } from "./service.js";

--- a/packages/core/src/user-store/postgres/store.ts
+++ b/packages/core/src/user-store/postgres/store.ts
@@ -1,6 +1,6 @@
 import { randomBytes } from "crypto";
 import { CompiledQuery, Kysely, PostgresDialect, sql } from "kysely";
-import pg from "pg";
+import type pg from "pg";
 
 import type { Schema } from "@/schema/types.js";
 import { blobToBigInt } from "@/utils/decode.js";

--- a/packages/core/src/utils/graphql-client.ts
+++ b/packages/core/src/utils/graphql-client.ts
@@ -1,8 +1,10 @@
-import { ApolloClient, HttpLink, InMemoryCache, split } from "@apollo/client";
-import { GraphQLWsLink } from "@apollo/client/link/subscriptions";
-import { getMainDefinition } from "@apollo/client/utilities";
+import apolloClientPkg from "@apollo/client";
+import { GraphQLWsLink } from "@apollo/client/link/subscriptions/index.js";
+import { getMainDefinition } from "@apollo/client/utilities/index.js";
 import { createClient } from "graphql-ws";
 import WebSocket from "ws";
+
+const { ApolloClient, HttpLink, InMemoryCache, split } = apolloClientPkg;
 
 /**
  * Method to create a client for GQL queries and subscriptions

--- a/packages/core/src/utils/graphql-client.ts
+++ b/packages/core/src/utils/graphql-client.ts
@@ -1,0 +1,45 @@
+import { ApolloClient, HttpLink, InMemoryCache, split } from "@apollo/client";
+import { GraphQLWsLink } from "@apollo/client/link/subscriptions";
+import { getMainDefinition } from "@apollo/client/utilities";
+import { createClient } from "graphql-ws";
+
+/**
+ * Method to create a client for GQL queries and subscriptions
+ * https://www.apollographql.com/docs/react/data/subscriptions
+ */
+export const createGqlClient = ({
+  httpEndpoint,
+  subscriptionEndpoint,
+}: {
+  httpEndpoint: string;
+  subscriptionEndpoint: string;
+}) => {
+  const httpLink = new HttpLink({
+    uri: httpEndpoint,
+  });
+
+  const wsLink = new GraphQLWsLink(
+    createClient({
+      url: subscriptionEndpoint,
+    })
+  );
+
+  const splitLink = split(
+    ({ query }) => {
+      const definition = getMainDefinition(query);
+      return (
+        definition.kind === "OperationDefinition" &&
+        definition.operation === "subscription"
+      );
+    },
+    wsLink,
+    httpLink
+  );
+
+  const client = new ApolloClient({
+    link: splitLink,
+    cache: new InMemoryCache(),
+  });
+
+  return client;
+};

--- a/packages/core/src/utils/graphql-client.ts
+++ b/packages/core/src/utils/graphql-client.ts
@@ -2,6 +2,7 @@ import { ApolloClient, HttpLink, InMemoryCache, split } from "@apollo/client";
 import { GraphQLWsLink } from "@apollo/client/link/subscriptions";
 import { getMainDefinition } from "@apollo/client/utilities";
 import { createClient } from "graphql-ws";
+import WebSocket from "ws";
 
 /**
  * Method to create a client for GQL queries and subscriptions
@@ -21,6 +22,7 @@ export const createGqlClient = ({
   const wsLink = new GraphQLWsLink(
     createClient({
       url: subscriptionEndpoint,
+      webSocketImpl: WebSocket,
     })
   );
 

--- a/packages/core/src/utils/graphql-client.ts
+++ b/packages/core/src/utils/graphql-client.ts
@@ -8,20 +8,14 @@ import WebSocket from "ws";
  * Method to create a client for GQL queries and subscriptions
  * https://www.apollographql.com/docs/react/data/subscriptions
  */
-export const createGqlClient = ({
-  httpEndpoint,
-  subscriptionEndpoint,
-}: {
-  httpEndpoint: string;
-  subscriptionEndpoint: string;
-}) => {
+export const createGqlClient = (gqlEndpoint: string) => {
   const httpLink = new HttpLink({
-    uri: httpEndpoint,
+    uri: gqlEndpoint,
   });
 
   const wsLink = new GraphQLWsLink(
     createClient({
-      url: subscriptionEndpoint,
+      url: gqlEndpoint,
       webSocketImpl: WebSocket,
     })
   );

--- a/packages/core/src/utils/server.ts
+++ b/packages/core/src/utils/server.ts
@@ -1,0 +1,110 @@
+import cors from "cors";
+import express from "express";
+import { createHttpTerminator } from "http-terminator";
+import { type Server as ServerInterface, createServer } from "node:http";
+
+import type { Common } from "@/Ponder";
+
+export class Server {
+  private common: Common;
+
+  port: number;
+  app?: express.Express;
+
+  private terminate?: () => Promise<void>;
+
+  constructor({ common, port }: { common: Common; port: number }) {
+    this.common = common;
+    this.port = port;
+  }
+
+  isHealthy = false;
+
+  async start() {
+    this.app = express();
+    this.app.use(cors({ methods: ["GET", "POST", "OPTIONS", "HEAD"] }));
+
+    const server = await new Promise<ServerInterface>((resolve, reject) => {
+      const server = createServer(this.app)
+        .on("error", (error) => {
+          if ((error as any).code === "EADDRINUSE") {
+            this.common.logger.warn({
+              service: "server",
+              msg: `Port ${this.port} was in use, trying port ${this.port + 1}`,
+            });
+            this.port += 1;
+            setTimeout(() => {
+              server.close();
+              server.listen(this.port);
+            }, 5);
+          } else {
+            reject(error);
+          }
+        })
+        .on("listening", () => {
+          resolve(server);
+        })
+        .listen(this.port);
+    });
+
+    const terminator = createHttpTerminator({ server });
+    this.terminate = () => terminator.terminate();
+
+    this.common.logger.info({
+      service: "server",
+      msg: `Started listening on port ${this.port}`,
+    });
+
+    this.app.post("/metrics", async (_, res) => {
+      try {
+        res.set("Content-Type", "text/plain; version=0.0.4; charset=utf-8");
+        res.end(await this.common.metrics.getMetrics());
+      } catch (error) {
+        res.status(500).end(error);
+      }
+    });
+
+    this.app.get("/metrics", async (_, res) => {
+      try {
+        res.set("Content-Type", "text/plain; version=0.0.4; charset=utf-8");
+        res.end(await this.common.metrics.getMetrics());
+      } catch (error) {
+        res.status(500).end(error);
+      }
+    });
+
+    // By default, the server will respond as unhealthy until historical events have
+    // been processed OR 4.5 minutes have passed since the app was created. This
+    // enables zero-downtime deployments on PaaS platforms like Railway and Render.
+    // Also see https://github.com/0xOlias/ponder/issues/24
+    this.app.get("/health", (_, res) => {
+      if (this.isHealthy) {
+        return res.status(200).send();
+      }
+
+      const max = this.common.options.maxHealthcheckDuration;
+      const elapsed = Math.floor(process.uptime());
+
+      if (elapsed > max) {
+        this.common.logger.warn({
+          service: "server",
+          msg: `Historical sync duration has exceeded the max healthcheck duration of ${max} seconds (current: ${elapsed}). Sevice is now responding as healthy and may serve incomplete data.`,
+        });
+        return res.status(200).send();
+      }
+
+      return res.status(503).send();
+    });
+
+    return server;
+  }
+
+  async kill() {
+    await this.terminate?.();
+
+    this.common.logger.debug({
+      service: "server",
+      msg: `Stopped listening on port ${this.port}`,
+    });
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -297,9 +297,15 @@ importers:
       '@cerc-io/peer':
         specifier: ^0.2.60
         version: 0.2.60
+      '@graphql-tools/schema':
+        specifier: ^10.0.0
+        version: 10.0.0(graphql@15.8.0)
       '@jridgewell/trace-mapping':
         specifier: ^0.3.17
         version: 0.3.19
+      apollo-type-bigint:
+        specifier: ^0.1.3
+        version: 0.1.3(graphql@15.8.0)
       async-mutex:
         specifier: ^0.4.0
         version: 0.4.0
@@ -348,6 +354,9 @@ importers:
       graphql-http:
         specifier: ^1.22.0
         version: 1.22.0(graphql@15.8.0)
+      graphql-subscriptions:
+        specifier: ^2.0.0
+        version: 2.0.0(graphql@15.8.0)
       graphql-ws:
         specifier: ^5.14.0
         version: 5.14.0(graphql@15.8.0)
@@ -400,6 +409,9 @@ importers:
         specifier: ^8.14.1
         version: 8.14.1
     devDependencies:
+      '@graphql-tools/utils':
+        specifier: ^10.0.6
+        version: 10.0.6(graphql@15.8.0)
       '@types/babel__code-frame':
         specifier: ^7.0.3
         version: 7.0.4
@@ -2983,13 +2995,47 @@ packages:
       assemblyscript: 0.19.10
     dev: true
 
+  /@graphql-tools/merge@9.0.0(graphql@15.8.0):
+    resolution: {integrity: sha512-J7/xqjkGTTwOJmaJQJ2C+VDBDOWJL3lKrHJN4yMaRLAJH3PosB7GiPRaSDZdErs0+F77sH2MKs2haMMkywzx7Q==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+    dependencies:
+      '@graphql-tools/utils': 10.0.6(graphql@15.8.0)
+      graphql: 15.8.0(patch_hash=qb2u6q36ugvr6swjr2i3rg76ty)
+      tslib: 2.6.2
+    dev: false
+
+  /@graphql-tools/schema@10.0.0(graphql@15.8.0):
+    resolution: {integrity: sha512-kf3qOXMFcMs2f/S8Y3A8fm/2w+GaHAkfr3Gnhh2LOug/JgpY/ywgFVxO3jOeSpSEdoYcDKLcXVjMigNbY4AdQg==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+    dependencies:
+      '@graphql-tools/merge': 9.0.0(graphql@15.8.0)
+      '@graphql-tools/utils': 10.0.6(graphql@15.8.0)
+      graphql: 15.8.0(patch_hash=qb2u6q36ugvr6swjr2i3rg76ty)
+      tslib: 2.6.2
+      value-or-promise: 1.0.12
+    dev: false
+
+  /@graphql-tools/utils@10.0.6(graphql@15.8.0):
+    resolution: {integrity: sha512-hZMjl/BbX10iagovakgf3IiqArx8TPsotq5pwBld37uIX1JiZoSbgbCIFol7u55bh32o6cfDEiiJgfAD5fbeyQ==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+    dependencies:
+      '@graphql-typed-document-node/core': 3.2.0(graphql@15.8.0)
+      dset: 3.1.2
+      graphql: 15.8.0(patch_hash=qb2u6q36ugvr6swjr2i3rg76ty)
+      tslib: 2.6.2
+
   /@graphql-typed-document-node/core@3.2.0(graphql@15.8.0):
     resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
     peerDependencies:
       graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
       graphql: 15.8.0(patch_hash=qb2u6q36ugvr6swjr2i3rg76ty)
-    dev: false
 
   /@headlessui/react@1.7.17(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-4am+tzvkqDSSgiwrsEpGWqgGo9dz8qU5M3znCkC4PgkpY4HcCZzEDEvozltGGGHIKl9jbXbZPSH5TWn4sWJdow==}
@@ -5535,6 +5581,14 @@ packages:
       - debug
     dev: true
 
+  /apollo-type-bigint@0.1.3(graphql@15.8.0):
+    resolution: {integrity: sha512-nyfwEWRZ+kon3Nnot20DufGm2EHZrkJoryYzw3soD+USdxhkcW434w1c/n+mjMLQDl86Z6EvlkvMX5Lordf2Wg==}
+    peerDependencies:
+      graphql: '>=0.13.0'
+    dependencies:
+      graphql: 15.8.0(patch_hash=qb2u6q36ugvr6swjr2i3rg76ty)
+    dev: false
+
   /app-module-path@2.2.0:
     resolution: {integrity: sha512-gkco+qxENJV+8vFcDiiFhuoSvRXb2a/QPqpSoWhVz829VNJfOTnELbBmPmNKFxf3xdNnw4DWCkzkDaavcX/1YQ==}
     dev: true
@@ -7468,7 +7522,6 @@ packages:
   /dset@3.1.2:
     resolution: {integrity: sha512-g/M9sqy3oHe477Ar4voQxWtaPIFw1jTdKZuomOjhCcBx9nHUNn0pu6NopuFFrTh/TRZIKEj+76vLWFu9BNKk+Q==}
     engines: {node: '>=4'}
-    dev: false
 
   /eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
@@ -9181,6 +9234,15 @@ packages:
       graphql: 16.8.1
     dev: true
 
+  /graphql-subscriptions@2.0.0(graphql@15.8.0):
+    resolution: {integrity: sha512-s6k2b8mmt9gF9pEfkxsaO1lTxaySfKoEJzEfmwguBbQ//Oq23hIXCfR1hm4kdh5hnR20RdwB+s3BCb+0duHSZA==}
+    peerDependencies:
+      graphql: ^15.7.2 || ^16.0.0
+    dependencies:
+      graphql: 15.8.0(patch_hash=qb2u6q36ugvr6swjr2i3rg76ty)
+      iterall: 1.3.0
+    dev: false
+
   /graphql-tag@2.12.6(graphql@15.8.0):
     resolution: {integrity: sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==}
     engines: {node: '>=10'}
@@ -9208,7 +9270,6 @@ packages:
   /graphql@15.8.0(patch_hash=qb2u6q36ugvr6swjr2i3rg76ty):
     resolution: {integrity: sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==}
     engines: {node: '>= 10.x'}
-    dev: false
     patched: true
 
   /graphql@16.8.1:
@@ -10437,6 +10498,10 @@ packages:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+    dev: false
+
+  /iterall@1.3.0:
+    resolution: {integrity: sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==}
     dev: false
 
   /iterator.prototype@1.1.2:
@@ -15410,6 +15475,11 @@ packages:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
     dev: true
+
+  /value-or-promise@1.0.12:
+    resolution: {integrity: sha512-Z6Uz+TYwEqE7ZN50gwn+1LCVo9ZVrpxRPOhOLnncYkY1ZzOYtrX8Fwf/rFktZ8R5mJms6EZf5TqNOMeZmnPq9Q==}
+    engines: {node: '>=12'}
+    dev: false
 
   /varint@6.0.0:
     resolution: {integrity: sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -351,6 +351,9 @@ importers:
       graphql:
         specifier: ^15.3.0
         version: 15.8.0(patch_hash=qb2u6q36ugvr6swjr2i3rg76ty)
+      graphql-http:
+        specifier: ^1.22.0
+        version: 1.22.0(graphql@15.8.0)
       graphql-subscriptions:
         specifier: ^2.0.0
         version: 2.0.0(graphql@15.8.0)
@@ -9213,6 +9216,15 @@ packages:
 
   /graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
+
+  /graphql-http@1.22.0(graphql@15.8.0):
+    resolution: {integrity: sha512-9RBUlGJWBFqz9LwfpmAbjJL/8j/HCNkZwPBU5+Bfmwez+1Ay43DocMNQYpIWsWqH0Ftv6PTNAh2aRnnMCBJgLw==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      graphql: '>=0.11 <=16'
+    dependencies:
+      graphql: 15.8.0(patch_hash=qb2u6q36ugvr6swjr2i3rg76ty)
+    dev: false
 
   /graphql-import-node@0.0.5(graphql@16.8.1):
     resolution: {integrity: sha512-OXbou9fqh9/Lm7vwXT0XoRN9J5+WCYKnbiTalgFDvkQERITRmcfncZs6aVABedd5B85yQU5EULS4a5pnbpuI0Q==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -351,9 +351,6 @@ importers:
       graphql:
         specifier: ^15.3.0
         version: 15.8.0(patch_hash=qb2u6q36ugvr6swjr2i3rg76ty)
-      graphql-http:
-        specifier: ^1.22.0
-        version: 1.22.0(graphql@15.8.0)
       graphql-subscriptions:
         specifier: ^2.0.0
         version: 2.0.0(graphql@15.8.0)
@@ -9216,15 +9213,6 @@ packages:
 
   /graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
-
-  /graphql-http@1.22.0(graphql@15.8.0):
-    resolution: {integrity: sha512-9RBUlGJWBFqz9LwfpmAbjJL/8j/HCNkZwPBU5+Bfmwez+1Ay43DocMNQYpIWsWqH0Ftv6PTNAh2aRnnMCBJgLw==}
-    engines: {node: '>=12'}
-    peerDependencies:
-      graphql: '>=0.11 <=16'
-    dependencies:
-      graphql: 15.8.0(patch_hash=qb2u6q36ugvr6swjr2i3rg76ty)
-    dev: false
 
   /graphql-import-node@0.0.5(graphql@16.8.1):
     resolution: {integrity: sha512-OXbou9fqh9/Lm7vwXT0XoRN9J5+WCYKnbiTalgFDvkQERITRmcfncZs6aVABedd5B85yQU5EULS4a5pnbpuI0Q==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -396,6 +396,9 @@ importers:
       viem:
         specifier: ^1.2.6
         version: 1.15.3(typescript@5.2.2)
+      ws:
+        specifier: ^8.14.1
+        version: 8.14.1
     devDependencies:
       '@types/babel__code-frame':
         specifier: ^7.0.3
@@ -433,6 +436,9 @@ importers:
       '@types/supertest':
         specifier: ^2.0.12
         version: 2.0.14
+      '@types/ws':
+        specifier: ^8.5.5
+        version: 8.5.5
       '@viem/anvil':
         specifier: ^0.0.6
         version: 0.0.6
@@ -4970,6 +4976,12 @@ packages:
 
   /@types/ws@7.4.7:
     resolution: {integrity: sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==}
+    dependencies:
+      '@types/node': 20.8.2
+    dev: true
+
+  /@types/ws@8.5.5:
+    resolution: {integrity: sha512-lwhs8hktwxSjf9UaZ9tG5M03PGogvFaH8gUgLNbN9HKIg0dvv6q+gkSuJ8HN4/VbyxkuLzCjlN7GquQ0gUJfIg==}
     dependencies:
       '@types/node': 20.8.2
     dev: true
@@ -15906,6 +15918,19 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+
+  /ws@8.14.1:
+    resolution: {integrity: sha512-4OOseMUq8AzRBI/7SLMUwO+FEDnguetSk7KMb1sHwvF2w2Wv5Hoj0nlifx8vtGsftE/jWHojPy8sMMzYLJ2G/A==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+    dev: false
 
   /ws@8.14.2:
     resolution: {integrity: sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -282,6 +282,9 @@ importers:
 
   packages/core:
     dependencies:
+      '@apollo/client':
+        specifier: ^3.8.3
+        version: 3.8.3(graphql-ws@5.14.0)(graphql@15.8.0)(react@17.0.2)
       '@babel/code-frame':
         specifier: ^7.18.6
         version: 7.22.13
@@ -345,6 +348,9 @@ importers:
       graphql-http:
         specifier: ^1.22.0
         version: 1.22.0(graphql@15.8.0)
+      graphql-ws:
+        specifier: ^5.14.0
+        version: 5.14.0(graphql@15.8.0)
       http-terminator:
         specifier: ^3.2.0
         version: 3.2.0
@@ -578,6 +584,42 @@ packages:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.3
       '@jridgewell/trace-mapping': 0.3.19
+
+  /@apollo/client@3.8.3(graphql-ws@5.14.0)(graphql@15.8.0)(react@17.0.2):
+    resolution: {integrity: sha512-mK86JM6hCpMEBGDgdO9U8ZYS8r9lPjXE1tVGpJMdSFUsIcXpmEfHUAbbFpPtYmxn8Qa7XsYy0dwDaDhpf4UUPw==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql-ws: ^5.5.5
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+      subscriptions-transport-ws: ^0.9.0 || ^0.11.0
+    peerDependenciesMeta:
+      graphql-ws:
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+      subscriptions-transport-ws:
+        optional: true
+    dependencies:
+      '@graphql-typed-document-node/core': 3.2.0(graphql@15.8.0)
+      '@wry/context': 0.7.3
+      '@wry/equality': 0.5.6
+      '@wry/trie': 0.4.3
+      graphql: 15.8.0(patch_hash=qb2u6q36ugvr6swjr2i3rg76ty)
+      graphql-tag: 2.12.6(graphql@15.8.0)
+      graphql-ws: 5.14.0(graphql@15.8.0)
+      hoist-non-react-statics: 3.3.2
+      optimism: 0.17.5
+      prop-types: 15.8.1
+      react: 17.0.2
+      response-iterator: 0.2.6
+      symbol-observable: 4.0.0
+      ts-invariant: 0.10.3
+      tslib: 2.6.2
+      zen-observable-ts: 1.2.5
+    dev: false
 
   /@babel/code-frame@7.22.13:
     resolution: {integrity: sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==}
@@ -2935,6 +2977,14 @@ packages:
       assemblyscript: 0.19.10
     dev: true
 
+  /@graphql-typed-document-node/core@3.2.0(graphql@15.8.0):
+    resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+    dependencies:
+      graphql: 15.8.0(patch_hash=qb2u6q36ugvr6swjr2i3rg76ty)
+    dev: false
+
   /@headlessui/react@1.7.17(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-4am+tzvkqDSSgiwrsEpGWqgGo9dz8qU5M3znCkC4PgkpY4HcCZzEDEvozltGGGHIKl9jbXbZPSH5TWn4sWJdow==}
     engines: {node: '>=10'}
@@ -5191,6 +5241,27 @@ packages:
       fast-url-parser: 1.1.3
       tslib: 2.6.2
     dev: true
+
+  /@wry/context@0.7.3:
+    resolution: {integrity: sha512-Nl8WTesHp89RF803Se9X3IiHjdmLBrIvPMaJkl+rKVJAYyPsz1TEUbu89943HpvujtSJgDUx9W4vZw3K1Mr3sA==}
+    engines: {node: '>=8'}
+    dependencies:
+      tslib: 2.6.2
+    dev: false
+
+  /@wry/equality@0.5.6:
+    resolution: {integrity: sha512-D46sfMTngaYlrH+OspKf8mIJETntFnf6Hsjb0V41jAXJ7Bx2kB8Rv8RCUujuVWYttFtHkUNp7g+FwxNQAr6mXA==}
+    engines: {node: '>=8'}
+    dependencies:
+      tslib: 2.6.2
+    dev: false
+
+  /@wry/trie@0.4.3:
+    resolution: {integrity: sha512-I6bHwH0fSf6RqQcnnXLJKhkSXG45MFral3GxPaY4uAl0LYDZM+YDVDAiU9bYwjTuysy1S0IeecWtmq1SZA3M1w==}
+    engines: {node: '>=8'}
+    dependencies:
+      tslib: 2.6.2
+    dev: false
 
   /JSONStream@1.3.2:
     resolution: {integrity: sha512-mn0KSip7N4e0UDPZHnqDsHECo5uGQrixQKnAskOM1BIB8hd7QKbd6il8IPRPudPHOeHiECoCFqhyMaRO9+nWyA==}
@@ -9098,6 +9169,25 @@ packages:
       graphql: 16.8.1
     dev: true
 
+  /graphql-tag@2.12.6(graphql@15.8.0):
+    resolution: {integrity: sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      graphql: ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+    dependencies:
+      graphql: 15.8.0(patch_hash=qb2u6q36ugvr6swjr2i3rg76ty)
+      tslib: 2.6.2
+    dev: false
+
+  /graphql-ws@5.14.0(graphql@15.8.0):
+    resolution: {integrity: sha512-itrUTQZP/TgswR4GSSYuwWUzrE/w5GhbwM2GX3ic2U7aw33jgEsayfIlvaj7/GcIvZgNMzsPTrE5hqPuFUiE5g==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      graphql: '>=0.11 <=16'
+    dependencies:
+      graphql: 15.8.0(patch_hash=qb2u6q36ugvr6swjr2i3rg76ty)
+    dev: false
+
   /graphql@15.5.0:
     resolution: {integrity: sha512-OmaM7y0kaK31NKG31q4YbD2beNYa6jBBKtMFT6gLYJljHLJr42IqJ8KX08u3Li/0ifzTU5HjmoOOrwa5BRLeDA==}
     engines: {node: '>= 10.x'}
@@ -9360,6 +9450,12 @@ packages:
       hash.js: 1.1.7
       minimalistic-assert: 1.0.1
       minimalistic-crypto-utils: 1.0.1
+
+  /hoist-non-react-statics@3.3.2:
+    resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
+    dependencies:
+      react-is: 16.13.1
+    dev: false
 
   /hosted-git-info@2.8.9:
     resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
@@ -12269,6 +12365,14 @@ packages:
     dependencies:
       mimic-fn: 4.0.0
 
+  /optimism@0.17.5:
+    resolution: {integrity: sha512-TEcp8ZwK1RczmvMnvktxHSF2tKgMWjJ71xEFGX5ApLh67VsMSTy1ZUlipJw8W+KaqgOmQ+4pqwkeivY89j+4Vw==}
+    dependencies:
+      '@wry/context': 0.7.3
+      '@wry/trie': 0.4.3
+      tslib: 2.6.2
+    dev: false
+
   /optionator@0.9.3:
     resolution: {integrity: sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==}
     engines: {node: '>= 0.8.0'}
@@ -12947,7 +13051,6 @@ packages:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
-    dev: true
 
   /property-information@6.3.0:
     resolution: {integrity: sha512-gVNZ74nqhRMiIUYWGQdosYetaKc83x8oT41a0LlV3AAFCAZwCpg4vmGkq8t34+cUhp3cnM4XDiU/7xlgK7HGrg==}
@@ -13153,7 +13256,6 @@ packages:
 
   /react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
-    dev: true
 
   /react-is@18.2.0:
     resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
@@ -13533,6 +13635,11 @@ packages:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
     dev: true
+
+  /response-iterator@0.2.6:
+    resolution: {integrity: sha512-pVzEEzrsg23Sh053rmDUvLSkGXluZio0qu8VT6ukrYuvtjVfCbDZH9d6PGXb8HZfzdNZt8feXv/jvUzlhRgLnw==}
+    engines: {node: '>=0.8'}
+    dev: false
 
   /restore-cursor@3.1.0:
     resolution: {integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==}
@@ -14406,6 +14513,11 @@ packages:
       stable: 0.1.8
     dev: true
 
+  /symbol-observable@4.0.0:
+    resolution: {integrity: sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==}
+    engines: {node: '>=0.10'}
+    dev: false
+
   /sync-request@6.1.0:
     resolution: {integrity: sha512-8fjNkrNlNCrVc/av+Jn+xxqfCjYaBoHqCsDz6mt030UMxJGr+GSfCV1dQt2gRtlL63+VPidwDVLr7V2OcTSdRw==}
     engines: {node: '>=8.0.0'}
@@ -14710,6 +14822,13 @@ packages:
   /ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
     dev: true
+
+  /ts-invariant@0.10.3:
+    resolution: {integrity: sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==}
+    engines: {node: '>=8'}
+    dependencies:
+      tslib: 2.6.2
+    dev: false
 
   /ts-node@10.9.1(@types/node@20.8.2)(typescript@5.2.2):
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
@@ -15947,6 +16066,16 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       '@types/yoga-layout': 1.9.2
+    dev: false
+
+  /zen-observable-ts@1.2.5:
+    resolution: {integrity: sha512-QZWQekv6iB72Naeake9hS1KxHlotfRpe+WGNbNx5/ta+R3DNjVO2bswf63gXlWDcs+EMd7XY8HfVQyP1X6T4Zg==}
+    dependencies:
+      zen-observable: 0.8.15
+    dev: false
+
+  /zen-observable@0.8.15:
+    resolution: {integrity: sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==}
     dev: false
 
   /zod@3.22.4:


### PR DESCRIPTION
Part of [Extract event indexing logic into eth-watcher](https://www.notion.so/Extract-event-indexing-logic-into-eth-watcher-a1ea8e6a1b1e4ed6a096423888ec5e6e) and [Pay for queries from watcher mode to indexer mode Ponder app](https://www.notion.so/Pay-for-queries-from-watcher-mode-to-indexer-mode-Ponder-app-4c6ad1be433b406aa093e95b458c4372)

- Extract EventAggregatorService interface
- Add `useGqlIndexing` flag in config to enable/disable fetching events from GQL
- Implement `getLogEvents` GQL query
- Implement GQL subscriptions for Sync service events
- Add `--mode` CLI arg to run app in `watcher` and `indexer` modes
- Use separate SQLite DBs (separate files) for user and event store to run the app decoupled
- Add query for historical checkpoint to sync watcher and indexer mode apps
- Fix imports for ESM setup