### PR TITLE
Add GQL query to get logs from indexer

### DIFF
--- a/packages/core/src/Ponder.ts
+++ b/packages/core/src/Ponder.ts
@@ -168,7 +168,7 @@ export class Ponder {
 
     const gqlClient = createGqlClient(
       config.indexer?.gqlEndpoint ??
-        `http://localhost:${common.options.indexingPort}/graphql`
+        `http://localhost:${common.options.indexerPort}/graphql`
     );
 
     this.eventAggregatorService = this.checkAppMode(AppMode.Watcher)

--- a/packages/core/src/config/options.ts
+++ b/packages/core/src/config/options.ts
@@ -21,7 +21,7 @@ export type Options = {
   logDir: string;
 
   port: number;
-  indexingPort: number;
+  indexerPort: number;
   maxHealthcheckDuration: number;
   telemetryUrl: string;
   telemetryDisabled: boolean;
@@ -63,7 +63,7 @@ export const buildOptions = ({
     logDir: ".ponder/logs",
 
     port: Number(process.env.PORT ?? 42069),
-    indexingPort: Number(process.env.INDEXING_PORT ?? 42070),
+    indexerPort: Number(process.env.INDEXING_PORT ?? 42070),
     maxHealthcheckDuration:
       configOptions?.maxHealthcheckDuration ?? railwayHealthcheckTimeout ?? 240,
 

--- a/packages/core/src/event-store/postgres/store.ts
+++ b/packages/core/src/event-store/postgres/store.ts
@@ -779,4 +779,9 @@ export class PostgresEventStore implements EventStore {
       if (events.length < pageSize) break;
     }
   }
+
+  // TODO: Implement method
+  async getEthLogs(): Promise<Log[]> {
+    return [];
+  }
 }

--- a/packages/core/src/event-store/sqlite/store.ts
+++ b/packages/core/src/event-store/sqlite/store.ts
@@ -816,7 +816,7 @@ export class SqliteEventStore implements EventStore {
     if (filter.fromBlock) {
       cmprs.push(
         cmpr(
-          "blocks.number",
+          "logs.blockNumber",
           ">=",
           sql`cast (${sql.val(intToBlob(filter.fromBlock))} as blob)`
         )
@@ -826,7 +826,7 @@ export class SqliteEventStore implements EventStore {
     if (filter.toBlock) {
       cmprs.push(
         cmpr(
-          "blocks.number",
+          "logs.blockNumber",
           "<=",
           sql`cast (${sql.val(intToBlob(filter.toBlock))} as blob)`
         )

--- a/packages/core/src/event-store/store.ts
+++ b/packages/core/src/event-store/store.ts
@@ -131,4 +131,13 @@ export interface EventStore {
       cursor?: Cursor;
     };
   }>;
+
+  // TODO: Implement method in eventStore for getting logs
+  getEthLogs(args: {
+    address: string;
+    topics: string[][];
+    fromBlock: string;
+    toBlock: string;
+    blockHash: string;
+  }): Log[];
 }

--- a/packages/core/src/event-store/store.ts
+++ b/packages/core/src/event-store/store.ts
@@ -132,12 +132,13 @@ export interface EventStore {
     };
   }>;
 
-  // TODO: Implement method in eventStore for getting logs
+  // TODO: Implement method in postgres eventStore for getting logs
   getEthLogs(args: {
-    address: string;
-    topics: string[][];
-    fromBlock: string;
-    toBlock: string;
-    blockHash: string;
-  }): Log[];
+    chainId: number;
+    address?: Address;
+    topics?: (Hex | Hex[] | null)[];
+    fromBlock?: number;
+    toBlock?: number;
+    blockHash?: Hex;
+  }): Promise<Log[]>;
 }

--- a/packages/core/src/indexing-server/resolvers.ts
+++ b/packages/core/src/indexing-server/resolvers.ts
@@ -86,15 +86,11 @@ export const getResolvers = ({
   const getEthLogs: IFieldResolver<any, unknown> = async (_, args) => {
     const { chainId, ...filterArgs } = args;
 
-    const logs = eventStore.getEthLogs({
+    // Log type returned by getEthLogs satisfied RpcLog type in viem
+    return eventStore.getEthLogs({
       chainId: args.chainId,
       ...filterArgs,
     });
-
-    console.log("logs", logs);
-
-    // TODO: Transform logs from eventStore to RpcLog type
-    return logs;
   };
 
   return {

--- a/packages/core/src/indexing-server/resolvers.ts
+++ b/packages/core/src/indexing-server/resolvers.ts
@@ -84,10 +84,17 @@ export const getResolvers = ({
   };
 
   const getEthLogs: IFieldResolver<any, unknown> = async (_, args) => {
-    console.log("args", args);
-    // TODO: Get logs from eventStore
-    // const iterator = eventStore.getEthLogs(args);
+    const { chainId, ...filterArgs } = args;
+
+    const logs = eventStore.getEthLogs({
+      chainId: args.chainId,
+      ...filterArgs,
+    });
+
+    console.log("logs", logs);
+
     // TODO: Transform logs from eventStore to RpcLog type
+    return logs;
   };
 
   return {

--- a/packages/core/src/indexing-server/resolvers.ts
+++ b/packages/core/src/indexing-server/resolvers.ts
@@ -83,12 +83,20 @@ export const getResolvers = ({
     };
   };
 
+  const getEthLogs: IFieldResolver<any, unknown> = async (_, args) => {
+    console.log("args", args);
+    // TODO: Get logs from eventStore
+    // const iterator = eventStore.getEthLogs(args);
+    // TODO: Transform logs from eventStore to RpcLog type
+  };
+
   return {
     BigInt: new ApolloBigInt("bigInt"),
 
     Query: {
       getLogEvents,
       getNetworkHistoricalSync,
+      getEthLogs,
     },
 
     Subscription: {

--- a/packages/core/src/indexing-server/schema.ts
+++ b/packages/core/src/indexing-server/schema.ts
@@ -18,9 +18,7 @@ export const indexingSchema = `
     logIndex: Int!
   }
 
-  # src/types/log.ts
-  type Log {
-    id: String!
+  type EthRpcLog {
     address: String!
     blockHash: String!
     blockNumber: BigInt!
@@ -30,6 +28,11 @@ export const indexingSchema = `
     topics: [String!]
     transactionHash: String!
     transactionIndex: Int!
+  }
+
+  # src/types/log.ts
+  type Log extends EthRpcLog {
+    id: String!
   }
 
   # src/types/log.ts
@@ -126,9 +129,18 @@ export const indexingSchema = `
       filters: [Filter!],
       cursor: CursorInput
     ): LogEventsResult!
+
     getNetworkHistoricalSync(
       chainId: Int!
     ): NetworkHistoricalSync!
+
+    getEthLogs(
+      address: String
+      topics: [[String!]]
+      fromBlock: String
+      toBlock: String
+      blockHash: String
+    ): [EthRpcLog!]
   }
 
   type Checkpoint {

--- a/packages/core/src/indexing-server/schema.ts
+++ b/packages/core/src/indexing-server/schema.ts
@@ -1,3 +1,15 @@
+const ethRpcLogFields = `
+  address: String!
+  blockHash: String!
+  blockNumber: BigInt!
+  data: String!
+  logIndex: Int!
+  removed: Boolean!
+  topics: [String!]
+  transactionHash: String!
+  transactionIndex: Int!
+`;
+
 export const indexingSchema = `
   scalar BigInt
 
@@ -19,19 +31,12 @@ export const indexingSchema = `
   }
 
   type EthRpcLog {
-    address: String!
-    blockHash: String!
-    blockNumber: BigInt!
-    data: String!
-    logIndex: Int!
-    removed: Boolean!
-    topics: [String!]
-    transactionHash: String!
-    transactionIndex: Int!
+    ${ethRpcLogFields}
   }
 
   # src/types/log.ts
-  type Log extends EthRpcLog {
+  type Log {
+    ${ethRpcLogFields}
     id: String!
   }
 
@@ -135,10 +140,11 @@ export const indexingSchema = `
     ): NetworkHistoricalSync!
 
     getEthLogs(
+      chainId: Int!
       address: String
       topics: [[String!]]
-      fromBlock: String
-      toBlock: String
+      fromBlock: Int
+      toBlock: Int
       blockHash: String
     ): [EthRpcLog!]
   }

--- a/packages/core/src/indexing-server/service.ts
+++ b/packages/core/src/indexing-server/service.ts
@@ -55,7 +55,7 @@ export class IndexingServerService {
 
     this.server = new Server({
       common,
-      port: common.options.indexingPort,
+      port: common.options.indexerPort,
     });
 
     // https://www.apollographql.com/docs/apollo-server/data/subscriptions#the-pubsub-class


### PR DESCRIPTION
Part of [Enable indexer to pull data from another indexer instead of RPC endpoint](https://www.notion.so/Enable-indexer-to-pull-data-from-another-indexer-instead-of-RPC-endpoint-53285776c0b9473790f81187b26f808b)

- Add GQL method `getEthLogs` in schema for fetching logs
- Add `getEthLogs` method in sqlite event store to fetch logs
  ```graphql
  getEthLogs(chainId: 42161, address: "0x6325439389e0797ab35752b4f43a14c004f22a9c", fromBlock: 3164126, toBlock: 3164146
  ) {
    address
    blockHash
    blockNumber
    data
    logIndex
    removed
    topics
    transactionHash
    transactionIndex
  }
  ```
- Following TODOs will be addressed in follow on PRs:
  - Implement `getEthLogs` method in Postgres event store 