### PR TITLE
Fetch logs data in historical sync service from indexer GQL server instead of RPC endpoint

### DIFF
--- a/packages/core/src/Ponder.ts
+++ b/packages/core/src/Ponder.ts
@@ -104,12 +104,13 @@ export class Ponder {
     const contracts = buildContracts({
       options,
       config,
+      common,
       paymentService: this.paymentService,
     });
 
     const networks = config.networks
       .map((network) =>
-        buildNetwork({ network, paymentService: this.paymentService })
+        buildNetwork({ network, paymentService: this.paymentService, common })
       )
       .filter((network) => {
         const hasLogFilters = logFilters.some(

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -41,6 +41,8 @@ export type ResolvedConfig = {
     chainId: number;
     /** RPC URL. Default: if available, a public RPC provider. */
     rpcUrl?: string;
+    /** Indexer URL for fetching network data. */
+    indexerUrl?: string;
     /** Polling frequency (in ms). Default: `1_000`. */
     pollingInterval?: number;
     /** Maximum concurrency of RPC requests during the historical sync. Default: `10`. */

--- a/packages/core/src/config/contracts.ts
+++ b/packages/core/src/config/contracts.ts
@@ -3,6 +3,7 @@ import type { Abi, Address } from "abitype";
 import type { ResolvedConfig } from "@/config/config.js";
 import type { Options } from "@/config/options.js";
 import type { PaymentService } from "@/payment/service.js";
+import type { Common } from "@/Ponder.js";
 
 import { buildAbi } from "./abi.js";
 import { type Network, buildNetwork } from "./networks.js";
@@ -17,10 +18,12 @@ export type Contract = {
 export function buildContracts({
   config,
   options,
+  common,
   paymentService,
 }: {
   config: ResolvedConfig;
   options: Options;
+  common: Common;
   paymentService?: PaymentService;
 }): Contract[] {
   return (config.contracts ?? []).map((contract) => {
@@ -39,7 +42,11 @@ export function buildContracts({
       );
     }
 
-    const network = buildNetwork({ network: rawNetwork, paymentService });
+    const network = buildNetwork({
+      network: rawNetwork,
+      paymentService,
+      common,
+    });
 
     return {
       name: contract.name,

--- a/packages/core/src/config/networks.ts
+++ b/packages/core/src/config/networks.ts
@@ -3,7 +3,9 @@ import { mainnet } from "viem/chains";
 
 import type { ResolvedConfig } from "@/config/config.js";
 import type { PaymentService } from "@/payment/service.js";
-import { PaidRPCProvider } from "@/utils/paid-rpc-provider.js";
+import type { Common } from "@/Ponder.js";
+import { IndexerGQLProvider } from "@/utils/providers/indexer-gql-provider.js";
+import { PaidRPCProvider } from "@/utils/providers/paid-rpc-provider.js";
 
 export type Network = {
   name: string;
@@ -21,9 +23,11 @@ const clients: Record<number, PublicClient | undefined> = {};
 export function buildNetwork({
   network,
   paymentService,
+  common,
 }: {
   network: ResolvedConfig["networks"][0];
   paymentService?: PaymentService;
+  common: Common;
 }) {
   let client = clients[network.chainId];
 
@@ -35,22 +39,27 @@ export function buildNetwork({
       network: network.name,
     };
 
-    let paidRPCProvider;
+    let customProvider;
 
-    if (paymentService && network.payments) {
-      paidRPCProvider = new PaidRPCProvider(
-        network as Network,
-        chain,
-        paymentService,
-        network.payments.paidRPCMethods
-      );
+    if (network.indexerUrl) {
+      // Use IndexerGQLProvider if indexerUrl is set for network
+      customProvider = new IndexerGQLProvider(network, chain, common);
+    } else {
+      if (paymentService && network.payments) {
+        // Use PaidRPCProvider if paymentService and network.payments are configured
+        // Provider is set only for network.rpcUrl and not network.indexerUrl
+        customProvider = new PaidRPCProvider(
+          network,
+          chain,
+          paymentService,
+          network.payments.paidRPCMethods
+        );
+      }
     }
 
     client = createPublicClient({
       chain,
-      transport: paidRPCProvider
-        ? custom(paidRPCProvider)
-        : http(network.rpcUrl),
+      transport: customProvider ? custom(customProvider) : http(network.rpcUrl),
     });
     clients[network.chainId] = client;
   }

--- a/packages/core/src/config/networks.ts
+++ b/packages/core/src/config/networks.ts
@@ -40,10 +40,16 @@ export function buildNetwork({
     };
 
     let customProvider;
+    const httpTransport = http(network.rpcUrl);
 
     if (network.indexerUrl) {
       // Use IndexerGQLProvider if indexerUrl is set for network
-      customProvider = new IndexerGQLProvider(network, chain, common);
+      customProvider = new IndexerGQLProvider(
+        network,
+        chain,
+        common,
+        httpTransport
+      );
     } else {
       if (paymentService && network.payments) {
         // Use PaidRPCProvider if paymentService and network.payments are configured
@@ -59,7 +65,7 @@ export function buildNetwork({
 
     client = createPublicClient({
       chain,
-      transport: customProvider ? custom(customProvider) : http(network.rpcUrl),
+      transport: customProvider ? custom(customProvider) : httpTransport,
     });
     clients[network.chainId] = client;
   }

--- a/packages/core/src/utils/providers/indexer-gql-provider.ts
+++ b/packages/core/src/utils/providers/indexer-gql-provider.ts
@@ -1,0 +1,138 @@
+import {
+  type ApolloClient,
+  type NormalizedCacheObject,
+  gql,
+} from "@apollo/client";
+import assert from "assert";
+import type { Chain } from "viem";
+import { fromHex, RpcRequestError } from "viem";
+
+import type { ResolvedConfig } from "@/config/config.js";
+import type { Common } from "@/Ponder.js";
+import { createGqlClient } from "@/utils/graphql-client.js";
+// TODO: Add payment to queries
+// import type { PaymentService } from "@/payment/service.js";
+
+export class IndexerGQLProvider {
+  private network: ResolvedConfig["networks"][0];
+  private chain: Chain;
+  private gqlClient: ApolloClient<NormalizedCacheObject>;
+  private common: Common;
+
+  constructor(
+    network: ResolvedConfig["networks"][0],
+    chain: Chain,
+    common: Common
+  ) {
+    assert(network.indexerUrl);
+    this.network = network;
+    this.chain = chain;
+    this.common = common;
+    this.gqlClient = createGqlClient(network.indexerUrl);
+  }
+
+  async request({
+    method,
+    params,
+  }: {
+    method: string;
+    params: unknown | object;
+  }): Promise<any> {
+    const chain = this.chain;
+    let headers;
+
+    const body = { method, params };
+
+    try {
+      const result = await this.indexerGQLRequest(body, chain.id, headers);
+
+      return result;
+    } catch (error: any) {
+      throw new RpcRequestError({
+        body,
+        error,
+        url: this.network.indexerUrl!,
+      });
+    }
+  }
+
+  private async indexerGQLRequest(
+    body: { method: string; params: unknown | object },
+    chainId: number,
+    headers?: {
+      [key: string]: string | number;
+    }
+  ) {
+    switch (body.method) {
+      case "eth_getLogs":
+        return this.gqlGetLogs(body.params, chainId, headers);
+
+      default:
+        this.common.logger.warn({
+          service: "indexer gql provider",
+          msg: `${body.method} method is not supported by indexer`,
+        });
+
+        break;
+    }
+  }
+
+  private async gqlGetLogs(
+    params: unknown | object,
+    chainId: number,
+    headers?: {
+      [key: string]: string | number;
+    }
+  ) {
+    const [filterArgs] = params as Array<any>;
+
+    // Transform blocks to number types for GQL query
+    filterArgs.fromBlock =
+      filterArgs.fromBlock && fromHex(filterArgs.fromBlock, "number");
+    filterArgs.toBlock =
+      filterArgs.toBlock && fromHex(filterArgs.fromBlock, "number");
+
+    const {
+      data: { getEthLogs },
+    } = await this.gqlClient.query({
+      query: gql`
+        query getEthLogs(
+          $chainId: Int!
+          $address: String
+          $topics: [[String!]]
+          $fromBlock: Int
+          $toBlock: Int
+          $blockHash: String
+        ) {
+          getEthLogs(
+            chainId: $chainId
+            address: $address
+            topics: $topics
+            fromBlock: $fromBlock
+            toBlock: $toBlock
+            blockHash: $blockHash
+          ) {
+            address
+            blockHash
+            blockNumber
+            data
+            logIndex
+            removed
+            topics
+            transactionHash
+            transactionIndex
+          }
+        }
+      `,
+      variables: {
+        chainId,
+        ...filterArgs,
+      },
+      context: {
+        headers,
+      },
+    });
+
+    return getEthLogs;
+  }
+}

--- a/packages/core/src/utils/providers/paid-rpc-provider.ts
+++ b/packages/core/src/utils/providers/paid-rpc-provider.ts
@@ -3,19 +3,19 @@ import type { Chain } from "viem";
 import { HttpRequestError, RpcRequestError, TimeoutError } from "viem";
 import { stringify } from "viem";
 
-import type { Network } from "@/config/networks.js";
+import type { ResolvedConfig } from "@/config/config.js";
 import type { PaymentService } from "@/payment/service.js";
 
 let id = 0;
 
 export class PaidRPCProvider {
-  network: Network;
+  network: ResolvedConfig["networks"][0];
   paymentService: PaymentService;
   paidRPCMethods: string[];
   chain: Chain;
 
   constructor(
-    network: Network,
+    network: ResolvedConfig["networks"][0],
     chain: Chain,
     paymentService: PaymentService,
     paidRPCMethods: string[]


### PR DESCRIPTION
Part of https://www.notion.so/Enable-indexer-to-pull-data-from-another-indexer-instead-of-RPC-endpoint-53285776c0b9473790f81187b26f808b

- Add network config option for indexerUrl
- Implement `IndexerGQLProvider` to be used in custom viem transport
  - `IndexerGQLProvider` requests data from indexer GQL server