### PR TITLE
[WIP] Fetch details for GQL queries payment from config file

### DIFF
--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1,3 +1,4 @@
+import type { BaseRatesConfig, PaymentsConfig } from "@cerc-io/util";
 import type { AbiEvent } from "abitype";
 import { build } from "esbuild";
 import { existsSync, rmSync } from "node:fs";
@@ -131,6 +132,9 @@ export type ResolvedConfig = {
     contractAddresses: { [key: string]: string };
     relayMultiAddr: string;
     store: string;
+    payments: PaymentsConfig;
+    // TODO: get baserates from file
+    baseRates: BaseRatesConfig;
   };
 };
 

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1,4 +1,4 @@
-import type { BaseRatesConfig, PaymentsConfig } from "@cerc-io/util";
+import type { PaymentsConfig } from "@cerc-io/util";
 import type { AbiEvent } from "abitype";
 import { build } from "esbuild";
 import { existsSync, rmSync } from "node:fs";
@@ -133,8 +133,6 @@ export type ResolvedConfig = {
     relayMultiAddr: string;
     store: string;
     payments: PaymentsConfig;
-    // TODO: get baserates from file
-    baseRates: BaseRatesConfig;
   };
 };
 

--- a/packages/core/src/event-aggregator/gql-service.ts
+++ b/packages/core/src/event-aggregator/gql-service.ts
@@ -85,8 +85,10 @@ export class GqlEventAggregatorService extends EventAggregatorService {
       const headers: { [key: string]: string } = {};
 
       // Pay and add header only if paymentService is setup
-      // TODO: Check if nitro is configured for indexer
-      if (this.paymentService && this.paymentService.checkIndexerPayments()) {
+      if (
+        this.paymentService &&
+        this.paymentService.isIndexerPaymentConfigured()
+      ) {
         const voucher = await this.paymentService.payIndexer();
         const paymentHeader = this.paymentService.getPaymentHeader(voucher);
         headers[PAYMENT_HEADER_KEY] = paymentHeader;

--- a/packages/core/src/event-aggregator/gql-service.ts
+++ b/packages/core/src/event-aggregator/gql-service.ts
@@ -86,7 +86,7 @@ export class GqlEventAggregatorService extends EventAggregatorService {
 
       // Pay and add header only if paymentService is setup
       // TODO: Check if nitro is configured for indexer
-      if (this.paymentService) {
+      if (this.paymentService && this.paymentService.checkIndexerPayments()) {
         const voucher = await this.paymentService.payIndexer();
         const paymentHeader = this.paymentService.getPaymentHeader(voucher);
         headers[PAYMENT_HEADER_KEY] = paymentHeader;

--- a/packages/core/src/payment/service.ts
+++ b/packages/core/src/payment/service.ts
@@ -33,30 +33,6 @@ interface IndexerPayments
   extends NonNullable<NonNullable<ResolvedConfig["indexer"]>["payments"]>,
     NitroChannelIds {}
 
-// TODO: Fetch from config
-const PAYMENTS_CONFIG = {
-  cache: {
-    maxAccounts: 1000,
-    accountTTLInSecs: 1800,
-    maxVouchersPerAccount: 1000,
-    voucherTTLInSecs: 300,
-    maxPaymentChannels: 10000,
-    paymentChannelTTLInSecs: 1800,
-  },
-  ratesFile: "",
-  requestTimeoutInSecs: 10,
-};
-
-// TODO: Fetch from rates config file
-const BASE_RATES_CONFIG = {
-  freeQueriesLimit: 10,
-  freeQueriesList: [],
-  queries: {
-    getLogEvents: "50",
-  },
-  mutations: {},
-};
-
 export class PaymentService {
   private config: NonNullable<ResolvedConfig["nitro"]>;
   private common: Common;
@@ -116,8 +92,8 @@ export class PaymentService {
 
     this.paymentsManager = new PaymentsManager(
       this.nitro,
-      PAYMENTS_CONFIG,
-      BASE_RATES_CONFIG
+      this.config.payments,
+      this.config.baseRates
     );
 
     const addNitroPeerPromises = Object.values(this.networkPaymentsMap).map(
@@ -336,5 +312,13 @@ export class PaymentService {
       paymentChannel,
       networkPayments.amount
     );
+  }
+
+  checkIndexerPayments(): boolean {
+    if (this.indexerPayments) {
+      return true;
+    } else {
+      return false;
+    }
   }
 }

--- a/packages/core/src/payment/service.ts
+++ b/packages/core/src/payment/service.ts
@@ -14,6 +14,7 @@ import type {
 } from "graphql";
 import type { RequestHeaders } from "graphql-http";
 import assert from "node:assert";
+import { readFileSync } from "node:fs";
 
 import type { RemoteNitro, ResolvedConfig } from "@/config/config";
 import type { Common } from "@/Ponder";
@@ -90,10 +91,14 @@ export class PaymentService {
       msg: `Nitro node setup with address ${this.nitro.node.address}`,
     });
 
+    const ratesFileData = readFileSync(this.config.payments.ratesFile, {
+      encoding: "utf-8",
+    });
+
     this.paymentsManager = new PaymentsManager(
       this.nitro,
       this.config.payments,
-      this.config.baseRates
+      JSON.parse(ratesFileData)
     );
 
     const addNitroPeerPromises = Object.values(this.networkPaymentsMap).map(

--- a/packages/core/src/payment/service.ts
+++ b/packages/core/src/payment/service.ts
@@ -15,6 +15,7 @@ import type {
 import type { RequestHeaders } from "graphql-http";
 import assert from "node:assert";
 import { readFileSync } from "node:fs";
+import path from "node:path";
 
 import type { RemoteNitro, ResolvedConfig } from "@/config/config";
 import type { Common } from "@/Ponder";
@@ -91,9 +92,17 @@ export class PaymentService {
       msg: `Nitro node setup with address ${this.nitro.node.address}`,
     });
 
-    const ratesFileData = readFileSync(this.config.payments.ratesFile, {
-      encoding: "utf-8",
-    });
+    const ratesFileData = readFileSync(
+      path.isAbsolute(this.config.payments.ratesFile)
+        ? this.config.payments.ratesFile
+        : path.resolve(
+            path.dirname(this.common.options.configFile),
+            path.basename(this.config.payments.ratesFile)
+          ),
+      {
+        encoding: "utf-8",
+      }
+    );
 
     this.paymentsManager = new PaymentsManager(
       this.nitro,
@@ -320,10 +329,6 @@ export class PaymentService {
   }
 
   checkIndexerPayments(): boolean {
-    if (this.indexerPayments) {
-      return true;
-    } else {
-      return false;
-    }
+    return Boolean(this.indexerPayments);
   }
 }

--- a/packages/core/src/payment/service.ts
+++ b/packages/core/src/payment/service.ts
@@ -328,7 +328,7 @@ export class PaymentService {
     );
   }
 
-  checkIndexerPayments(): boolean {
+  isIndexerPaymentConfigured(): boolean {
     return Boolean(this.indexerPayments);
   }
 }


### PR DESCRIPTION
Part of [Fetch GQL queries payment config from rates file](https://www.notion.so/Fetch-indexer-GQL-queries-payment-config-from-rates-file-34a2a22cd220447caaaa9246b86455f2)

- Add `nitro.payments` config
- Read rates config from filepath set in `nitro.payments.ratesFile`