### PR TITLE
Add GQL query for fetching block and txs data

### DIFF
--- a/packages/core/src/config/networks.ts
+++ b/packages/core/src/config/networks.ts
@@ -12,6 +12,7 @@ export type Network = {
   chainId: number;
   client: PublicClient;
   rpcUrl?: string;
+  indexerUrl?: string;
   pollingInterval: number;
   defaultMaxBlockRange: number;
   maxRpcRequestConcurrency: number;
@@ -44,12 +45,7 @@ export function buildNetwork({
 
     if (network.indexerUrl) {
       // Use IndexerGQLProvider if indexerUrl is set for network
-      customProvider = new IndexerGQLProvider(
-        network,
-        chain,
-        common,
-        httpTransport
-      );
+      customProvider = new IndexerGQLProvider(network, chain, common);
     } else {
       if (paymentService && network.payments) {
         // Use PaidRPCProvider if paymentService and network.payments are configured
@@ -75,6 +71,7 @@ export function buildNetwork({
     chainId: network.chainId,
     client,
     rpcUrl: network.rpcUrl,
+    indexerUrl: network.indexerUrl,
     pollingInterval: network.pollingInterval ?? 1_000,
     defaultMaxBlockRange: getDefaultMaxBlockRange(network),
     maxRpcRequestConcurrency: network.maxRpcRequestConcurrency ?? 10,

--- a/packages/core/src/event-store/postgres/store.ts
+++ b/packages/core/src/event-store/postgres/store.ts
@@ -8,14 +8,7 @@ import {
   sql,
 } from "kysely";
 import type pg from "pg";
-import type {
-  Address,
-  Hash,
-  Hex,
-  RpcBlock,
-  RpcLog,
-  RpcTransaction,
-} from "viem";
+import type { Address, Hex, RpcBlock, RpcLog, RpcTransaction } from "viem";
 
 import type { Block } from "@/types/block.js";
 import type { Log } from "@/types/log.js";
@@ -788,14 +781,12 @@ export class PostgresEventStore implements EventStore {
   }
 
   // TODO: Implement method
-  async getEthLogs(): Promise<Log[]> {
+  async getEthLogs(): Promise<RpcLog[]> {
     return [];
   }
 
   // TODO: Implement method
-  async getEthBlock(): Promise<
-    { block: Block; transactions: Transaction[] | Hash[] } | undefined
-  > {
+  async getEthBlock(): Promise<RpcBlock | undefined> {
     return;
   }
 }

--- a/packages/core/src/event-store/postgres/store.ts
+++ b/packages/core/src/event-store/postgres/store.ts
@@ -8,7 +8,14 @@ import {
   sql,
 } from "kysely";
 import type pg from "pg";
-import type { Address, Hex, RpcBlock, RpcLog, RpcTransaction } from "viem";
+import type {
+  Address,
+  Hash,
+  Hex,
+  RpcBlock,
+  RpcLog,
+  RpcTransaction,
+} from "viem";
 
 import type { Block } from "@/types/block.js";
 import type { Log } from "@/types/log.js";
@@ -783,5 +790,12 @@ export class PostgresEventStore implements EventStore {
   // TODO: Implement method
   async getEthLogs(): Promise<Log[]> {
     return [];
+  }
+
+  // TODO: Implement method
+  async getEthBlock(): Promise<
+    { block: Block; transactions: Transaction[] | Hash[] } | undefined
+  > {
+    return;
   }
 }

--- a/packages/core/src/event-store/sqlite/store.ts
+++ b/packages/core/src/event-store/sqlite/store.ts
@@ -820,7 +820,7 @@ export class SqliteEventStore implements EventStore {
 
     // If neither blockHash or blockNumber is provided, latest block is returned with order and limit query
     const [requestedBlock] = await query
-      .orderBy("blocks.blockNumber", "desc")
+      .orderBy("blocks.number", "desc")
       .limit(1)
       .execute();
 

--- a/packages/core/src/event-store/sqlite/store.ts
+++ b/packages/core/src/event-store/sqlite/store.ts
@@ -2,21 +2,13 @@ import assert from "assert";
 import type Sqlite from "better-sqlite3";
 import {
   type ExpressionBuilder,
-  type SelectQueryBuilder,
   Kysely,
   Migrator,
   NO_MIGRATIONS,
   sql,
   SqliteDialect,
 } from "kysely";
-import type {
-  Address,
-  Hash,
-  Hex,
-  RpcBlock,
-  RpcLog,
-  RpcTransaction,
-} from "viem";
+import type { Address, Hex, RpcBlock, RpcLog, RpcTransaction } from "viem";
 
 import type { Block } from "@/types/block.js";
 import type { Log } from "@/types/log.js";
@@ -36,6 +28,9 @@ import {
   rpcToSqliteBlock,
   rpcToSqliteLog,
   rpcToSqliteTransaction,
+  sqliteToRpcBlock,
+  sqliteToRpcLog,
+  sqliteToRpcTransaction,
 } from "./format.js";
 import { migrationProvider } from "./migrations.js";
 
@@ -708,7 +703,7 @@ export class SqliteEventStore implements EventStore {
     fromBlock?: number;
     toBlock?: number;
     blockHash?: Hex;
-  }): Promise<Log[]> {
+  }): Promise<RpcLog[]> {
     const { blockHash, ...commonFilterArgs } = args;
 
     assert(
@@ -749,20 +744,7 @@ export class SqliteEventStore implements EventStore {
       .execute();
 
     return requestedLogs.map((row) => {
-      return {
-        address: row.address,
-        blockHash: row.blockHash,
-        blockNumber: blobToBigInt(row.blockNumber),
-        data: row.data,
-        id: row.id,
-        logIndex: Number(row.logIndex),
-        removed: false,
-        topics: [row.topic0, row.topic1, row.topic2, row.topic3].filter(
-          (t): t is Hex => t !== null
-        ) as [Hex, ...Hex[]] | [],
-        transactionHash: row.transactionHash,
-        transactionIndex: Number(row.transactionIndex),
-      };
+      return sqliteToRpcLog(row);
     });
   }
 
@@ -771,38 +753,32 @@ export class SqliteEventStore implements EventStore {
     blockHash?: Hex;
     blockNumber?: number;
     fullTransactions?: boolean;
-  }): Promise<
-    { block: Block; transactions: Transaction[] | Hash[] } | undefined
-  > {
+  }): Promise<RpcBlock | undefined> {
     const { chainId, blockHash, blockNumber, fullTransactions = false } = args;
 
-    let query: SelectQueryBuilder<
-      EventStoreTables,
-      "blocks" | "transactions",
-      any
-    > = this.db
+    let query = this.db
       .selectFrom("blocks")
       .select([
-        "blocks.baseFeePerGas as block_baseFeePerGas",
-        "blocks.chainId as block_chainId",
-        "blocks.difficulty as block_difficulty",
-        "blocks.extraData as block_extraData",
-        "blocks.gasLimit as block_gasLimit",
-        "blocks.gasUsed as block_gasUsed",
-        "blocks.hash as block_hash",
-        "blocks.logsBloom as block_logsBloom",
-        "blocks.miner as block_miner",
-        "blocks.mixHash as block_mixHash",
-        "blocks.nonce as block_nonce",
-        "blocks.number as block_number",
-        "blocks.parentHash as block_parentHash",
-        "blocks.receiptsRoot as block_receiptsRoot",
-        "blocks.sha3Uncles as block_sha3Uncles",
-        "blocks.size as block_size",
-        "blocks.stateRoot as block_stateRoot",
-        "blocks.timestamp as block_timestamp",
-        "blocks.totalDifficulty as block_totalDifficulty",
-        "blocks.transactionsRoot as block_transactionsRoot",
+        "blocks.baseFeePerGas",
+        "blocks.chainId",
+        "blocks.difficulty",
+        "blocks.extraData",
+        "blocks.gasLimit",
+        "blocks.gasUsed",
+        "blocks.hash",
+        "blocks.logsBloom",
+        "blocks.miner",
+        "blocks.mixHash",
+        "blocks.nonce",
+        "blocks.number",
+        "blocks.parentHash",
+        "blocks.receiptsRoot",
+        "blocks.sha3Uncles",
+        "blocks.size",
+        "blocks.stateRoot",
+        "blocks.timestamp",
+        "blocks.totalDifficulty",
+        "blocks.transactionsRoot",
       ])
       .where("blocks.chainId", "=", sql`cast (${sql.val(chainId)} as integer)`);
 
@@ -828,113 +804,46 @@ export class SqliteEventStore implements EventStore {
       const txsQuery = this.db
         .selectFrom("transactions")
         .select([
-          "transactions.hash as tx_hash",
-          "transactions.blockHash as tx_blockHash",
+          "transactions.hash",
+          "transactions.blockHash",
+          "transactions.chainId",
         ])
         .where(
           "transactions.chainId",
           "=",
           sql`cast (${sql.val(chainId)} as integer)`
         )
-        .where("transactions.blockHash", "=", requestedBlock.block_hash)
+        .where("transactions.blockHash", "=", requestedBlock.hash)
         .$if(fullTransactions, (qb) =>
           qb.select([
-            "transactions.accessList as tx_accessList",
-            "transactions.blockNumber as tx_blockNumber",
-            "transactions.chainId as tx_chainId",
-            "transactions.from as tx_from",
-            "transactions.gas as tx_gas",
-            "transactions.gasPrice as tx_gasPrice",
-            "transactions.input as tx_input",
-            "transactions.maxFeePerGas as tx_maxFeePerGas",
-            "transactions.maxPriorityFeePerGas as tx_maxPriorityFeePerGas",
-            "transactions.nonce as tx_nonce",
-            "transactions.r as tx_r",
-            "transactions.s as tx_s",
-            "transactions.to as tx_to",
-            "transactions.transactionIndex as tx_transactionIndex",
-            "transactions.type as tx_type",
-            "transactions.value as tx_value",
-            "transactions.v as tx_v",
+            "transactions.accessList",
+            "transactions.blockNumber",
+            "transactions.from",
+            "transactions.gas",
+            "transactions.gasPrice",
+            "transactions.input",
+            "transactions.maxFeePerGas",
+            "transactions.maxPriorityFeePerGas",
+            "transactions.nonce",
+            "transactions.r",
+            "transactions.s",
+            "transactions.to",
+            "transactions.transactionIndex",
+            "transactions.type",
+            "transactions.value",
+            "transactions.v",
           ])
         );
 
       const requestedTxs = await txsQuery.execute();
 
-      return {
-        block: {
-          baseFeePerGas: requestedBlock.block_baseFeePerGas
-            ? blobToBigInt(requestedBlock.block_baseFeePerGas)
-            : null,
-          difficulty: blobToBigInt(requestedBlock.block_difficulty),
-          extraData: requestedBlock.block_extraData,
-          gasLimit: blobToBigInt(requestedBlock.block_gasLimit),
-          gasUsed: blobToBigInt(requestedBlock.block_gasUsed),
-          hash: requestedBlock.block_hash,
-          logsBloom: requestedBlock.block_logsBloom,
-          miner: requestedBlock.block_miner,
-          mixHash: requestedBlock.block_mixHash,
-          nonce: requestedBlock.block_nonce,
-          number: blobToBigInt(requestedBlock.block_number),
-          parentHash: requestedBlock.block_parentHash,
-          receiptsRoot: requestedBlock.block_receiptsRoot,
-          sha3Uncles: requestedBlock.block_sha3Uncles,
-          size: blobToBigInt(requestedBlock.block_size),
-          stateRoot: requestedBlock.block_stateRoot,
-          timestamp: blobToBigInt(requestedBlock.block_timestamp),
-          totalDifficulty: blobToBigInt(requestedBlock.block_totalDifficulty),
-          transactionsRoot: requestedBlock.block_transactionsRoot,
-        },
-        transactions: fullTransactions
-          ? requestedTxs.map(
-              (row): Transaction => ({
-                blockHash: row.tx_blockHash,
-                blockNumber: blobToBigInt(row.tx_blockNumber!),
-                from: row.tx_from!,
-                gas: blobToBigInt(row.tx_gas!),
-                hash: row.tx_hash,
-                input: row.tx_input!,
-                nonce: Number(row.tx_nonce),
-                r: row.tx_r!,
-                s: row.tx_s!,
-                to: row.tx_to!,
-                transactionIndex: Number(row.tx_transactionIndex),
-                value: blobToBigInt(row.tx_value!),
-                v: blobToBigInt(row.tx_v!),
-                ...(row.tx_type === "0x0"
-                  ? {
-                      type: "legacy",
-                      gasPrice: blobToBigInt(row.tx_gasPrice!),
-                    }
-                  : row.tx_type === "0x1"
-                  ? {
-                      type: "eip2930",
-                      gasPrice: blobToBigInt(row.tx_gasPrice!),
-                      accessList: JSON.parse(row.tx_accessList!),
-                    }
-                  : row.tx_type === "0x2"
-                  ? {
-                      type: "eip1559",
-                      maxFeePerGas: blobToBigInt(row.tx_maxFeePerGas!),
-                      maxPriorityFeePerGas: blobToBigInt(
-                        row.tx_maxPriorityFeePerGas!
-                      ),
-                    }
-                  : row.tx_type === "0x7e"
-                  ? {
-                      type: "deposit",
-                      maxFeePerGas: blobToBigInt(row.tx_maxFeePerGas!),
-                      maxPriorityFeePerGas: blobToBigInt(
-                        row.tx_maxPriorityFeePerGas!
-                      ),
-                    }
-                  : {
-                      type: row.tx_type!,
-                    }),
-              })
-            )
-          : requestedTxs.map((row) => row.tx_hash),
-      };
+      const rpcTxs = fullTransactions
+        ? requestedTxs.map((tx) =>
+            sqliteToRpcTransaction(tx as InsertableTransaction)
+          )
+        : requestedTxs.map((tx) => tx.hash);
+
+      return sqliteToRpcBlock(requestedBlock, rpcTxs);
     }
 
     return;

--- a/packages/core/src/event-store/store.ts
+++ b/packages/core/src/event-store/store.ts
@@ -157,8 +157,6 @@ export interface EventStore {
     fullTransactions?: boolean;
     latest?: boolean;
   }): Promise<
-    | { block: Block; transactions: Transaction[] | Hash[] }
-    | undefined
-    | undefined
+    { block: Block; transactions: Transaction[] | Hash[] } | undefined
   >;
 }

--- a/packages/core/src/event-store/store.ts
+++ b/packages/core/src/event-store/store.ts
@@ -1,12 +1,5 @@
 import type { Kysely, Migrator } from "kysely";
-import type {
-  Address,
-  Hash,
-  Hex,
-  RpcBlock,
-  RpcLog,
-  RpcTransaction,
-} from "viem";
+import type { Address, Hex, RpcBlock, RpcLog, RpcTransaction } from "viem";
 
 import type { Block } from "@/types/block.js";
 import type { Log } from "@/types/log.js";
@@ -147,7 +140,7 @@ export interface EventStore {
     fromBlock?: number;
     toBlock?: number;
     blockHash?: Hex;
-  }): Promise<Log[]>;
+  }): Promise<RpcLog[]>;
 
   // TODO: Implement method in postgres eventStore for getting blocks
   getEthBlock(args: {
@@ -156,7 +149,5 @@ export interface EventStore {
     blockNumber?: number;
     fullTransactions?: boolean;
     latest?: boolean;
-  }): Promise<
-    { block: Block; transactions: Transaction[] | Hash[] } | undefined
-  >;
+  }): Promise<RpcBlock | undefined>;
 }

--- a/packages/core/src/event-store/store.ts
+++ b/packages/core/src/event-store/store.ts
@@ -1,5 +1,12 @@
 import type { Kysely, Migrator } from "kysely";
-import type { Address, Hex, RpcBlock, RpcLog, RpcTransaction } from "viem";
+import type {
+  Address,
+  Hash,
+  Hex,
+  RpcBlock,
+  RpcLog,
+  RpcTransaction,
+} from "viem";
 
 import type { Block } from "@/types/block.js";
 import type { Log } from "@/types/log.js";
@@ -141,4 +148,17 @@ export interface EventStore {
     toBlock?: number;
     blockHash?: Hex;
   }): Promise<Log[]>;
+
+  // TODO: Implement method in postgres eventStore for getting blocks
+  getEthBlock(args: {
+    chainId: number;
+    blockHash?: Hex;
+    blockNumber?: number;
+    fullTransactions?: boolean;
+    latest?: boolean;
+  }): Promise<
+    | { block: Block; transactions: Transaction[] | Hash[] }
+    | undefined
+    | undefined
+  >;
 }

--- a/packages/core/src/indexing-server/resolvers.ts
+++ b/packages/core/src/indexing-server/resolvers.ts
@@ -96,30 +96,20 @@ export const getResolvers = ({
   const getEthBlock: IFieldResolver<any, unknown> = async (_, args) => {
     const { chainId, ...filterArgs } = args;
 
-    const data = await eventStore.getEthBlock({
+    const rpcBlock = await eventStore.getEthBlock({
       chainId: args.chainId,
       ...filterArgs,
     });
 
-    if (!data) {
+    if (!rpcBlock) {
       return;
     }
 
-    const result: { [key: string]: any } = {
-      ...data.block,
-      // Set empty fields to satisfy RpcBlock type
-      // Following fields are not stored in event store DB by the indexer
-      sealFields: [],
-      uncles: [],
+    return {
+      ...rpcBlock,
+      txHashes: !filterArgs.fullTransactions ? rpcBlock.transactions : null,
+      transactions: filterArgs.fullTransactions ? rpcBlock.transactions : null,
     };
-
-    if (filterArgs.fullTransactions) {
-      result.transactions = data.transactions;
-    } else {
-      result.txHashes = data.transactions;
-    }
-
-    return result;
   };
 
   return {

--- a/packages/core/src/indexing-server/resolvers.ts
+++ b/packages/core/src/indexing-server/resolvers.ts
@@ -93,6 +93,28 @@ export const getResolvers = ({
     });
   };
 
+  const getEthBlock: IFieldResolver<any, unknown> = async (_, args) => {
+    const { chainId, ...filterArgs } = args;
+
+    const data = await eventStore.getEthBlock({
+      chainId: args.chainId,
+      ...filterArgs,
+    });
+
+    if (!data) {
+      return;
+    }
+
+    return {
+      ...data.block,
+      // Set empty fields to satisfy RpcBlock type
+      // Following fields are not stored in event store DB by the indexer
+      sealFields: [],
+      uncles: [],
+      transactions: data.transactions,
+    };
+  };
+
   return {
     BigInt: new ApolloBigInt("bigInt"),
 
@@ -100,6 +122,7 @@ export const getResolvers = ({
       getLogEvents,
       getNetworkHistoricalSync,
       getEthLogs,
+      getEthBlock,
     },
 
     Subscription: {

--- a/packages/core/src/indexing-server/resolvers.ts
+++ b/packages/core/src/indexing-server/resolvers.ts
@@ -105,14 +105,21 @@ export const getResolvers = ({
       return;
     }
 
-    return {
+    const result: { [key: string]: any } = {
       ...data.block,
       // Set empty fields to satisfy RpcBlock type
       // Following fields are not stored in event store DB by the indexer
       sealFields: [],
       uncles: [],
-      transactions: data.transactions,
     };
+
+    if (filterArgs.fullTransactions) {
+      result.transactions = data.transactions;
+    } else {
+      result.txHashes = data.transactions;
+    }
+
+    return result;
   };
 
   return {

--- a/packages/core/src/indexing-server/schema.ts
+++ b/packages/core/src/indexing-server/schema.ts
@@ -59,7 +59,9 @@ export const indexingSchema = `
   type EthRpcBlock {
     ${blockFields}
     sealFields: [String!]!
-    uncles: [String]
+    uncles: [String!]!
+    transactions: [Transaction!]
+    txHashes: [String!]
   }
 
   # src/types/log.ts

--- a/packages/core/src/indexing-server/schema.ts
+++ b/packages/core/src/indexing-server/schema.ts
@@ -10,6 +10,28 @@ const ethRpcLogFields = `
   transactionIndex: Int!
 `;
 
+const blockFields = `
+  baseFeePerGas: BigInt
+  difficulty: BigInt!
+  extraData: String!
+  gasLimit: BigInt!
+  gasUsed: BigInt!
+  hash: String!
+  logsBloom: String!
+  miner: String!
+  mixHash: String!
+  nonce: String!
+  number: BigInt!
+  parentHash: String!
+  receiptsRoot: String!
+  sha3Uncles: String!
+  size: BigInt!
+  stateRoot: String!
+  timestamp: BigInt!
+  totalDifficulty: BigInt!
+  transactionsRoot: String!
+`;
+
 export const indexingSchema = `
   scalar BigInt
 
@@ -34,6 +56,12 @@ export const indexingSchema = `
     ${ethRpcLogFields}
   }
 
+  type EthRpcBlock {
+    ${blockFields}
+    sealFields: [String!]!
+    uncles: [String]
+  }
+
   # src/types/log.ts
   type Log {
     ${ethRpcLogFields}
@@ -42,25 +70,7 @@ export const indexingSchema = `
 
   # src/types/log.ts
   type Block {
-    baseFeePerGas: BigInt
-    difficulty: BigInt!
-    extraData: String!
-    gasLimit: BigInt!
-    gasUsed: BigInt!
-    hash: String!
-    logsBloom: String!
-    miner: String!
-    mixHash: String!
-    nonce: String!
-    number: BigInt!
-    parentHash: String!
-    receiptsRoot: String!
-    sha3Uncles: String!
-    size: BigInt!
-    stateRoot: String!
-    timestamp: BigInt!
-    totalDifficulty: BigInt!
-    transactionsRoot: String!
+    ${blockFields}
   }
 
   type AccessListItem {
@@ -147,6 +157,13 @@ export const indexingSchema = `
       toBlock: Int
       blockHash: String
     ): [EthRpcLog!]
+
+    getEthBlock(
+      chainId: Int!
+      blockNumber: Int
+      blockHash: String
+      fullTransactions: Boolean
+    ): EthRpcBlock
   }
 
   type Checkpoint {

--- a/packages/core/src/realtime-sync/service.ts
+++ b/packages/core/src/realtime-sync/service.ts
@@ -82,12 +82,17 @@ export class RealtimeSyncService extends Emittery<RealtimeSyncEvents> {
       1
     );
 
-    // Set the finalized block number according to the network's finality threshold.
-    // If the finality block count is greater than the latest block number, set to zero.
-    const finalizedBlockNumber = Math.max(
-      0,
-      latestBlockNumber - this.network.finalityBlockCount
-    );
+    let finalizedBlockNumber = latestBlockNumber;
+
+    // Calculate finalizedBlockNumber incase network is not using indexer GQL endpoint
+    if (!this.network.indexerUrl) {
+      // Set the finalized block number according to the network's finality threshold.
+      // If the finality block count is greater than the latest block number, set to zero.
+      finalizedBlockNumber = Math.max(
+        0,
+        latestBlockNumber - this.network.finalityBlockCount
+      );
+    }
     this.finalizedBlockNumber = finalizedBlockNumber;
 
     // Add the latest block to the unfinalized block queue.

--- a/packages/core/src/utils/providers/indexer-gql-provider.ts
+++ b/packages/core/src/utils/providers/indexer-gql-provider.ts
@@ -1,7 +1,7 @@
 import { type ApolloClient, type NormalizedCacheObject } from "@apollo/client";
 import apolloClientPkg from "@apollo/client";
 import assert from "assert";
-import type { Chain, HttpTransport } from "viem";
+import type { Chain } from "viem";
 import { fromHex, RpcRequestError } from "viem";
 
 import type { ResolvedConfig } from "@/config/config.js";
@@ -17,19 +17,16 @@ export class IndexerGQLProvider {
   private chain: Chain;
   private gqlClient: ApolloClient<NormalizedCacheObject>;
   private common: Common;
-  private httpTransport: HttpTransport;
 
   constructor(
     network: ResolvedConfig["networks"][0],
     chain: Chain,
-    common: Common,
-    httpTransport: HttpTransport
+    common: Common
   ) {
     assert(network.indexerUrl);
     this.network = network;
     this.chain = chain;
     this.common = common;
-    this.httpTransport = httpTransport;
     this.gqlClient = createGqlClient(network.indexerUrl);
   }
 
@@ -67,23 +64,24 @@ export class IndexerGQLProvider {
   ) {
     switch (body.method) {
       case "eth_getLogs":
-        return this.gqlGetLogs(body.params, chainId, headers);
+        return this.getGQLLogs(body.params, chainId, headers);
+
+      case "eth_getBlockByNumber":
+        return this.getGQLBlock(body.params, chainId, false, headers);
+
+      case "eth_getBlockByHash":
+        return this.getGQLBlock(body.params, chainId, true, headers);
 
       default: {
         this.common.logger.warn({
           service: "indexer gql provider",
           msg: `${body.method} method is not supported by indexer. Using httpTransport`,
         });
-
-        // TODO: Use GQL query for eth_getBlockByNumber and eth_getBlockByHash
-        // TODO: Remove use of httpTransport
-        const { request } = this.httpTransport({ chain: this.chain });
-        return request(body);
       }
     }
   }
 
-  private async gqlGetLogs(
+  private async getGQLLogs(
     params: unknown | object,
     chainId: number,
     headers?: {
@@ -140,5 +138,105 @@ export class IndexerGQLProvider {
     });
 
     return getEthLogs;
+  }
+
+  private async getGQLBlock(
+    params: unknown | object,
+    chainId: number,
+    useBlockHash = false,
+    headers?: {
+      [key: string]: string | number;
+    }
+  ) {
+    const [blockTag, fullTransactions] = params as Array<any>;
+
+    const variables: { [key: string]: any } = {
+      chainId,
+      fullTransactions,
+    };
+
+    if (useBlockHash) {
+      variables.blockHash = blockTag;
+    } else {
+      // If blockTag is latest neither blockHash or blockNumber is set and latest block is retrieved
+      if (blockTag != "latest") {
+        variables.blockNumber = fromHex(blockTag, "number");
+      }
+    }
+
+    const {
+      data: { getEthBlock },
+    } = await this.gqlClient.query({
+      query: gql`
+        query getEthBlock(
+          $chainId: Int!
+          $blockHash: String
+          $blockNumber: Int
+          $fullTransactions: Boolean
+        ) {
+          getEthBlock(
+            chainId: $chainId
+            blockHash: $blockHash
+            blockNumber: $blockNumber
+            fullTransactions: $fullTransactions
+          ) {
+            baseFeePerGas
+            difficulty
+            extraData
+            gasLimit
+            gasUsed
+            hash
+            logsBloom
+            miner
+            mixHash
+            nonce
+            number
+            parentHash
+            receiptsRoot
+            sha3Uncles
+            size
+            stateRoot
+            timestamp
+            totalDifficulty
+            transactionsRoot
+            sealFields
+            uncles
+            transactions {
+              blockHash
+              blockNumber
+              from
+              gas
+              hash
+              input
+              nonce
+              r
+              s
+              to
+              transactionIndex
+              v
+              value
+              type
+              gasPrice
+              accessList {
+                address
+                storageKeys
+              }
+              maxFeePerGas
+              maxPriorityFeePerGas
+            }
+            txHashes
+          }
+        }
+      `,
+      variables,
+      context: {
+        headers,
+      },
+    });
+
+    return {
+      ...getEthBlock,
+      transactions: getEthBlock.transactions ?? getEthBlock.txHashes,
+    };
   }
 }

--- a/packages/core/src/utils/providers/indexer-gql-provider.ts
+++ b/packages/core/src/utils/providers/indexer-gql-provider.ts
@@ -236,7 +236,9 @@ export class IndexerGQLProvider {
 
     return {
       ...getEthBlock,
-      transactions: getEthBlock.transactions ?? getEthBlock.txHashes,
+      transactions: fullTransactions
+        ? getEthBlock.transactions
+        : getEthBlock.txHashes,
     };
   }
 }


### PR DESCRIPTION
Part of [Enable indexer to pull data from another indexer instead of RPC endpoint](https://www.notion.so/Enable-indexer-to-pull-data-from-another-indexer-instead-of-RPC-endpoint-53285776c0b9473790f81187b26f808b)

- Add GQL query to fetch block and txs data from event store
- Use GQL query for fetching block data in `IndexerGQLProvider`
  - Remove fallback http transport
- Fix transformation of SQLite to RPC network data for GQL response
- Skip calculating finalized block number in realtime sync service if fetching network data from an indexer