### PR TITLE
Fetch block from RPC endpoint for running realtime sync service

### DIFF
--- a/packages/core/src/event-store/postgres/store.ts
+++ b/packages/core/src/event-store/postgres/store.ts
@@ -786,7 +786,7 @@ export class PostgresEventStore implements EventStore {
   }
 
   // TODO: Implement method
-  async getEthBlock(): Promise<RpcBlock | undefined> {
-    return;
+  async getEthBlock(): Promise<RpcBlock | null> {
+    return null;
   }
 }

--- a/packages/core/src/event-store/sqlite/format.ts
+++ b/packages/core/src/event-store/sqlite/format.ts
@@ -68,7 +68,9 @@ export function sqliteToRpcBlock(
   transactions: RpcTransaction[] | Hash[]
 ): RpcBlock {
   return {
-    baseFeePerGas: block.baseFeePerGas ? toHex(block.baseFeePerGas) : null,
+    baseFeePerGas: block.baseFeePerGas
+      ? toHex(blobToBigInt(block.baseFeePerGas))
+      : null,
     difficulty: toHex(blobToBigInt(block.difficulty)),
     extraData: block.extraData,
     gasLimit: toHex(blobToBigInt(block.gasLimit)),
@@ -196,8 +198,10 @@ export function sqliteToRpcTransaction(
     accessList: JSON.parse(transaction.accessList!),
     chainId: toHex(transaction.chainId),
     type: transaction.type as "0x2",
-    maxFeePerGas: toHex(transaction.maxFeePerGas!),
-    maxPriorityFeePerGas: toHex(transaction.maxPriorityFeePerGas!),
+    maxFeePerGas: toHex(blobToBigInt(transaction.maxFeePerGas!)),
+    maxPriorityFeePerGas: toHex(
+      blobToBigInt(transaction.maxPriorityFeePerGas!)
+    ),
   };
 }
 

--- a/packages/core/src/event-store/sqlite/store.ts
+++ b/packages/core/src/event-store/sqlite/store.ts
@@ -753,7 +753,7 @@ export class SqliteEventStore implements EventStore {
     blockHash?: Hex;
     blockNumber?: number;
     fullTransactions?: boolean;
-  }): Promise<RpcBlock | undefined> {
+  }): Promise<RpcBlock | null> {
     const { chainId, blockHash, blockNumber, fullTransactions = false } = args;
 
     let query = this.db
@@ -846,7 +846,7 @@ export class SqliteEventStore implements EventStore {
       return sqliteToRpcBlock(requestedBlock, rpcTxs);
     }
 
-    return;
+    return null;
   }
 
   private buildFilterAndCmprs(

--- a/packages/core/src/event-store/store.ts
+++ b/packages/core/src/event-store/store.ts
@@ -149,5 +149,5 @@ export interface EventStore {
     blockNumber?: number;
     fullTransactions?: boolean;
     latest?: boolean;
-  }): Promise<RpcBlock | undefined>;
+  }): Promise<RpcBlock | null>;
 }

--- a/packages/core/src/indexing-server/resolvers.ts
+++ b/packages/core/src/indexing-server/resolvers.ts
@@ -1,7 +1,9 @@
 import type { IFieldResolver, IResolvers } from "@graphql-tools/utils";
 import type { PubSub } from "graphql-subscriptions";
 import { createRequire } from "node:module";
+import { type RpcBlock, numberToHex } from "viem";
 
+import type { Network } from "@/config/networks.js";
 import type { EventStore } from "@/event-store/store.js";
 import { blobToBigInt } from "@/utils/decode.js";
 import { intToBlob } from "@/utils/encode.js";
@@ -29,10 +31,12 @@ export const getResolvers = ({
   eventStore,
   pubsub,
   networkCheckpoints,
+  networks,
 }: {
   eventStore: EventStore;
   pubsub: PubSub;
   networkCheckpoints: NetworkCheckpoints;
+  networks: Network[];
 }): IResolvers<any, unknown> => {
   const getLogEvents: IFieldResolver<any, unknown> = async (_, args) => {
     const { fromTimestamp, toTimestamp, filters, cursor } = args;
@@ -95,21 +99,41 @@ export const getResolvers = ({
 
   const getEthBlock: IFieldResolver<any, unknown> = async (_, args) => {
     const { chainId, ...filterArgs } = args;
+    const { blockHash, blockNumber, fullTransactions } = filterArgs;
+    const blockTag =
+      blockHash ?? (blockNumber && numberToHex(blockNumber)) ?? "latest";
 
-    const rpcBlock = await eventStore.getEthBlock({
-      chainId: args.chainId,
-      ...filterArgs,
-    });
+    let rpcBlock: RpcBlock | null = null;
 
-    if (!rpcBlock) {
-      return;
+    if (blockTag !== "latest") {
+      // Try fetching block from DB if blockTag is not latest
+      rpcBlock = await eventStore.getEthBlock({
+        chainId: args.chainId,
+        ...filterArgs,
+      });
     }
 
-    return {
-      ...rpcBlock,
-      txHashes: !filterArgs.fullTransactions ? rpcBlock.transactions : null,
-      transactions: filterArgs.fullTransactions ? rpcBlock.transactions : null,
-    };
+    if (!rpcBlock) {
+      const network = networks.find((network) => network.chainId === chainId);
+
+      // Fetch from network client if block not found in DB
+      rpcBlock = await network!.client.request({
+        method: blockHash ? "eth_getBlockByHash" : "eth_getBlockByNumber",
+        params: [blockTag, fullTransactions],
+      });
+    }
+
+    if (rpcBlock) {
+      return {
+        ...rpcBlock,
+        // sealFields doesn't exist in block returned by RPC endpoint
+        sealFields: rpcBlock.sealFields ?? [],
+        txHashes: !fullTransactions ? rpcBlock.transactions : null,
+        transactions: fullTransactions ? rpcBlock.transactions : null,
+      };
+    }
+
+    return;
   };
 
   return {

--- a/packages/core/src/indexing-server/resolvers.ts
+++ b/packages/core/src/indexing-server/resolvers.ts
@@ -117,6 +117,7 @@ export const getResolvers = ({
       const network = networks.find((network) => network.chainId === chainId);
 
       // Fetch from network client if block not found in DB
+      // TODO: Cache network RPC calls for already fetched blocks
       rpcBlock = await network!.client.request({
         method: blockHash ? "eth_getBlockByHash" : "eth_getBlockByNumber",
         params: [blockTag, fullTransactions],

--- a/packages/core/src/indexing-server/service.ts
+++ b/packages/core/src/indexing-server/service.ts
@@ -30,6 +30,7 @@ export class IndexingServerService {
   private pubsub: PubSub;
   private server: Server;
   private paymentService?: PaymentService;
+  private networks: Network[];
 
   // Per-network checkpoints.
   private networkCheckpoints: NetworkCheckpoints;
@@ -52,6 +53,7 @@ export class IndexingServerService {
     this.common = common;
     this.eventStore = eventStore;
     this.paymentService = paymentService;
+    this.networks = networks;
 
     this.server = new Server({
       common,
@@ -61,7 +63,7 @@ export class IndexingServerService {
     // https://www.apollographql.com/docs/apollo-server/data/subscriptions#the-pubsub-class
     this.pubsub = new PubSub();
 
-    this.networkCheckpoints = networks.reduce(
+    this.networkCheckpoints = this.networks.reduce(
       (acc: NetworkCheckpoints, network) => {
         acc[network.chainId] = {
           isHistoricalSyncComplete: false,
@@ -88,6 +90,7 @@ export class IndexingServerService {
         eventStore: this.eventStore,
         pubsub: this.pubsub,
         networkCheckpoints: this.networkCheckpoints,
+        networks: this.networks,
       }),
     });
 

--- a/packages/core/src/realtime-sync/service.ts
+++ b/packages/core/src/realtime-sync/service.ts
@@ -84,15 +84,13 @@ export class RealtimeSyncService extends Emittery<RealtimeSyncEvents> {
 
     let finalizedBlockNumber = latestBlockNumber;
 
-    // Calculate finalizedBlockNumber incase network is not using indexer GQL endpoint
-    if (!this.network.indexerUrl) {
-      // Set the finalized block number according to the network's finality threshold.
-      // If the finality block count is greater than the latest block number, set to zero.
-      finalizedBlockNumber = Math.max(
-        0,
-        latestBlockNumber - this.network.finalityBlockCount
-      );
-    }
+    // Set the finalized block number according to the network's finality threshold.
+    // If the finality block count is greater than the latest block number, set to zero.
+    finalizedBlockNumber = Math.max(
+      0,
+      latestBlockNumber - this.network.finalityBlockCount
+    );
+
     this.finalizedBlockNumber = finalizedBlockNumber;
 
     // Add the latest block to the unfinalized block queue.

--- a/packages/core/src/utils/graphql-client.ts
+++ b/packages/core/src/utils/graphql-client.ts
@@ -37,6 +37,11 @@ export const createGqlClient = (gqlEndpoint: string) => {
   const client = new ApolloClient({
     link: splitLink,
     cache: new InMemoryCache(),
+    defaultOptions: {
+      query: {
+        fetchPolicy: "no-cache",
+      },
+    },
   });
 
   return client;

--- a/packages/core/src/utils/providers/indexer-gql-provider.ts
+++ b/packages/core/src/utils/providers/indexer-gql-provider.ts
@@ -234,11 +234,15 @@ export class IndexerGQLProvider {
       },
     });
 
-    return {
-      ...getEthBlock,
-      transactions: fullTransactions
-        ? getEthBlock.transactions
-        : getEthBlock.txHashes,
-    };
+    if (getEthBlock) {
+      return {
+        ...getEthBlock,
+        transactions: fullTransactions
+          ? getEthBlock.transactions
+          : getEthBlock.txHashes,
+      };
+    }
+
+    return null;
   }
 }


### PR DESCRIPTION
Part of [Enable indexer to pull data from another indexer instead of RPC endpoint](https://www.notion.so/Enable-indexer-to-pull-data-from-another-indexer-instead-of-RPC-endpoint-53285776c0b9473790f81187b26f808b)

- Fetch block from network RPC endpoint if not found in indexer DB
- Fixes in transform of SQLite to RPC network data
- Disable cache in GQL client