### PR TITLE
Return latest head block from realtime sync service in indexer GQL query

### DIFF
--- a/packages/core/src/Ponder.ts
+++ b/packages/core/src/Ponder.ts
@@ -163,8 +163,8 @@ export class Ponder {
     this.indexingServerService = new IndexingServerService({
       common,
       eventStore: this.eventStore,
-      networks,
       paymentService: this.paymentService,
+      networkSyncServices: this.networkSyncServices,
     });
 
     const gqlClient = createGqlClient(

--- a/packages/core/src/indexing-server/resolvers.ts
+++ b/packages/core/src/indexing-server/resolvers.ts
@@ -2,7 +2,7 @@ import type { IFieldResolver, IResolvers } from "@graphql-tools/utils";
 import type { PubSub } from "graphql-subscriptions";
 import assert from "node:assert";
 import { createRequire } from "node:module";
-import { numberToHex } from "viem";
+import { type RpcBlock, numberToHex } from "viem";
 
 import type { Network } from "@/config/networks.js";
 import type { EventStore } from "@/event-store/store.js";
@@ -129,13 +129,17 @@ export const getResolvers = ({
       }
     }
 
-    // Try fetching block from DB
-    let rpcBlock = await eventStore.getEthBlock({
-      chainId: args.chainId,
-      blockHash,
-      blockNumber,
-      fullTransactions,
-    });
+    let rpcBlock: RpcBlock | null = null;
+
+    if (blockHash || blockNumber) {
+      // Try fetching block from DB if blockHash or blockNumber specified
+      rpcBlock = await eventStore.getEthBlock({
+        chainId: args.chainId,
+        blockHash,
+        blockNumber,
+        fullTransactions,
+      });
+    }
 
     // If the block is not fetched from DB, check for blockTag
     // If blockTag is latest, realtime sync service has not started

--- a/packages/core/src/realtime-sync/service.ts
+++ b/packages/core/src/realtime-sync/service.ts
@@ -70,7 +70,7 @@ export class RealtimeSyncService extends Emittery<RealtimeSyncEvents> {
   get headBlock() {
     const blocksLength = this.blocks.length;
 
-    return blocksLength ? this.blocks[blocksLength] : null;
+    return blocksLength ? this.blocks[blocksLength - 1] : null;
   }
 
   setup = async () => {

--- a/packages/core/src/realtime-sync/service.ts
+++ b/packages/core/src/realtime-sync/service.ts
@@ -67,6 +67,12 @@ export class RealtimeSyncService extends Emittery<RealtimeSyncEvents> {
     this.queue = this.buildQueue();
   }
 
+  get headBlock() {
+    const blocksLength = this.blocks.length;
+
+    return blocksLength ? this.blocks[blocksLength] : null;
+  }
+
   setup = async () => {
     // Fetch the latest block for the network.
     const latestBlock = await this.getLatestBlock();


### PR DESCRIPTION
Part of [Enable indexer to pull data from another indexer instead of RPC endpoint](https://www.notion.so/Enable-indexer-to-pull-data-from-another-indexer-instead-of-RPC-endpoint-53285776c0b9473790f81187b26f808b)

- In `getEthBlock` GQL query return latest head block from realtime sync service if recipient indexer requests for latest block